### PR TITLE
feat: Add metadata support to fit_transform method

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,18 @@ toorpia_client = toorPIA()
 import pandas as pd
 
 df = pd.read_csv("input.csv")
+# Basic usage
 results = toorpia_client.fit_transform(df)
+
+# Extended usage with metadata
+results = toorpia_client.fit_transform(
+    data=df,
+    label="Production Line 1 - Pressure Gauge",  # Optional: Name to identify the target equipment
+    tag="Pressure Sensor",  # Optional: Classification category for the map
+    description="Pressure gauge used in the 3rd process of Production Line 1. Model: ABC-123",  # Optional: Detailed description
+    random_seed=123  # Optional: Random seed for clustering (default: 42)
+)
+
 print(toorpia_client.shareUrl)  # Get the share URL for the created map
 ```
 

--- a/toorpia/client.py
+++ b/toorpia/client.py
@@ -39,12 +39,22 @@ class toorPIA:
             return None
 
     @pre_authentication
-    def fit_transform(self, data):
+    def fit_transform(self, data, label=None, tag=None, description=None, random_seed=42):
         headers = {'Content-Type': 'application/json', 'session-key': self.session_key}
 
         # DataFrame形式で与えられたdataをJSON形式に変換して、バックエンドに送信する
         data_json = data.to_json(orient='split')  # split形式でJSON文字列に変換
         data_dict = json.loads(data_json)  # JSON文字列を辞書型に変換
+
+        # オプションパラメータを追加
+        if label is not None:
+            data_dict['label'] = label
+        if tag is not None:
+            data_dict['tag'] = tag
+        if description is not None:
+            data_dict['description'] = description
+        if random_seed != 42:
+            data_dict['randomSeed'] = random_seed
 
         response = requests.post(f"{API_URL}/data/fit_transform", json=data_dict, headers=headers)
         if response.status_code == 200:


### PR DESCRIPTION
Added optional parameters to the fit_transform method:
- label: Name to identify the target equipment
- tag: Classification category for the map
- description: Detailed description of the map
- random_seed: Random seed for clustering (default: 42)

These metadata fields allow users to better organize and identify maps,
especially when used as base maps for equipment or machinery monitoring.
Updated README with examples of how to use the new parameters.

Fixes #4
Fixes #3