### PR TITLE
feat: Implement add plot history feature in toorPIA client

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ df_add = pd.read_csv("add.csv")
 # Using the most recent map
 results_add = toorpia_client.addplot(df_add)
 print(toorpia_client.shareUrl)  # Get the share URL for the updated map
+print(toorpia_client.currentAddPlotNo)  # Get the add plot number
 
 # Using a specific map number
 results_add = toorpia_client.addplot(df_add, 123)
@@ -61,7 +62,31 @@ results_add = toorpia_client.addplot(df_add, 123)
 results_add = toorpia_client.addplot(df_add, "/path/to/basemap/data/directory")
 ```
 
-#### 3. Listing Available Maps
+#### 3. Working with Add Plot History
+
+toorPIA now supports maintaining a history of add plots for each map. This allows you to track multiple add plot operations and access their results at any time.
+
+```python
+# List all add plots for a specific map
+add_plots = toorpia_client.list_addplots(toorpia_client.mapNo)
+print(f"Found {len(add_plots)} add plots for this map")
+
+# Get a specific add plot by its number
+add_plot_info = toorpia_client.get_addplot(toorpia_client.mapNo, 1)  # Get the first add plot
+
+# Access the add plot data
+xy_data = add_plot_info['xyData']  # NumPy array of coordinates
+add_plot_metadata = add_plot_info['addPlot']  # Metadata about the add plot
+share_url = add_plot_info['shareUrl']  # Share URL for this specific add plot
+
+# Iterate through all add plots
+if add_plots:
+    for add_plot in add_plots:
+        print(f"Add Plot #{add_plot['addPlotNo']} created at {add_plot['createdAt']}")
+        print(f"Records: {add_plot['nRecord']}")
+```
+
+#### 4. Listing Available Maps
 
 ```python
 map_list = toorpia_client.list_map()
@@ -151,6 +176,21 @@ toorpia_client.addplot(data)  # Uses most recent map
 toorpia_client.addplot(data, 123)  # Uses map number 123
 toorpia_client.addplot(data, "/path/to/map")  # Uses map data from the specified directory
 ```
+
+### Add Plot History Features
+
+The client now maintains a history of all add plot operations for each map:
+
+1. **Tracking Add Plot Numbers**: Each add plot operation receives a unique number within its map, accessible via the `currentAddPlotNo` property.
+
+2. **Listing Add Plots**: Use `list_addplots(map_no)` to retrieve all add plots for a specific map.
+
+3. **Retrieving Specific Add Plots**: Use `get_addplot(map_no, addplot_no)` to fetch details about a specific add plot, including its coordinates and metadata.
+
+These features enable more sophisticated analysis workflows, such as:
+- Comparing multiple datasets against the same base map
+- Tracking changes in data over time
+- Building a history of analysis operations for better reproducibility
 
 ## Error Handling
 

--- a/samples/test_addplot_history.py
+++ b/samples/test_addplot_history.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Test script for the add plot history features of the toorPIA client.
+This script demonstrates:
+1. Creating a base map
+2. Adding multiple add plots to the same map
+3. Listing all add plots for a map
+4. Retrieving specific add plot information
+"""
+
+import os
+import sys
+import pandas as pd
+import numpy as np
+from toorpia import toorPIA
+
+def print_separator(title):
+    """Print a separator with a title."""
+    print("\n" + "=" * 60)
+    print(f" {title} ".center(60, "="))
+    print("=" * 60 + "\n")
+
+def main():
+    # Set environment variables if not already set
+    # You can also set these in your shell before running the script
+    if not os.environ.get('TOORPIA_API_URL'):
+        os.environ['TOORPIA_API_URL'] = 'http://localhost:3000'
+    
+    print_separator("1. Initializing toorPIA Client")
+    client = toorPIA()
+    print("Client initialized.\n")
+
+    # Load sample data
+    print_separator("2. Loading Sample Data")
+    base_data_path = os.path.join(os.path.dirname(__file__), 'biopsy.csv')
+    add_data_path = os.path.join(os.path.dirname(__file__), 'biopsy-add.csv')
+    
+    if not os.path.exists(base_data_path) or not os.path.exists(add_data_path):
+        print(f"Error: Sample data files not found in {os.path.dirname(__file__)}")
+        print(f"Looked for: {base_data_path} and {add_data_path}")
+        return 1
+    
+    base_data = pd.read_csv(base_data_path)
+    add_data = pd.read_csv(add_data_path)
+    
+    print(f"Base data loaded: {base_data.shape[0]} rows, {base_data.shape[1]} columns")
+    print(f"Add data loaded: {add_data.shape[0]} rows, {add_data.shape[1]} columns\n")
+
+    # Create base map
+    print_separator("3. Creating Base Map")
+    try:
+        result = client.fit_transform(base_data)
+        print(f"Base map created successfully. Map No: {client.mapNo}")
+        print(f"Share URL: {client.shareUrl}\n")
+    except Exception as e:
+        print(f"Error creating base map: {str(e)}")
+        return 1
+
+    # Create first add plot
+    print_separator("4. Creating First Add Plot")
+    try:
+        add_result_1 = client.addplot(add_data)
+        print(f"First add plot created. Add Plot No: {client.currentAddPlotNo}")
+        print(f"Share URL: {client.shareUrl}")
+        print(f"Result shape: {add_result_1.shape}\n")
+    except Exception as e:
+        print(f"Error creating first add plot: {str(e)}")
+        return 1
+
+    # Create second add plot
+    print_separator("5. Creating Second Add Plot")
+    try:
+        add_result_2 = client.addplot(add_data)
+        print(f"Second add plot created. Add Plot No: {client.currentAddPlotNo}")
+        print(f"Share URL: {client.shareUrl}")
+        print(f"Result shape: {add_result_2.shape}\n")
+    except Exception as e:
+        print(f"Error creating second add plot: {str(e)}")
+        return 1
+
+    # List all add plots
+    print_separator("6. Listing All Add Plots")
+    try:
+        add_plots = client.list_addplots(client.mapNo)
+        print(f"Found {len(add_plots)} add plots for map {client.mapNo}")
+        
+        if add_plots:
+            for add_plot in add_plots:
+                print(f"\nAdd Plot #{add_plot['addPlotNo']}:")
+                print(f"  Created at: {add_plot['createdAt']}")
+                print(f"  Records: {add_plot['nRecord']}")
+                print(f"  Files: {add_plot['segmentFile']}, {add_plot['xyFile']}")
+                print(f"  Share URL: {add_plot.get('shareUrl', 'N/A')}")
+    except Exception as e:
+        print(f"Error listing add plots: {str(e)}")
+        return 1
+
+    # Get specific add plot
+    print_separator("7. Getting Specific Add Plot")
+    try:
+        add_plot_info = client.get_addplot(client.mapNo, 1)  # Get the first add plot
+        print(f"Retrieved add plot 1 information:")
+        print(f"  Metadata: {add_plot_info['addPlot']}")
+        print(f"  XY Data Shape: {add_plot_info['xyData'].shape}")
+        print(f"  Share URL: {add_plot_info['shareUrl']}\n")
+    except Exception as e:
+        print(f"Error getting specific add plot: {str(e)}")
+        return 1
+
+    # Test error case - non-existent add plot
+    print_separator("8. Testing Error Case - Non-existent Add Plot")
+    try:
+        non_existent_plot = client.get_addplot(client.mapNo, 999)  # This should not exist
+        if non_existent_plot is None:
+            print("Test passed: Correctly returned None for non-existent add plot\n")
+        else:
+            print("Test failed: Should have returned None for non-existent add plot\n")
+    except Exception as e:
+        print(f"Exception while testing non-existent add plot: {str(e)}\n")
+
+    print_separator("Test Completed Successfully")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='toorpia',
-    version='0.2.0',
+    version='0.3.0',
     author='toor Inc.',
     author_email='takaeda@toor.jpn.com',
     description='A client library for accessing the toorPIA high-dimensional data analysis API',


### PR DESCRIPTION
This commit adds support for the add plot history feature to the toorPIA client library,
allowing users to access multiple add plot operations performed on the same base map.

Key changes:
- Added new class attributes `currentAddPlotNo` and `addPlots` to track add plot operations
- Updated `addplot` method to store the add plot number returned from the server
- Added new methods:
  - `list_addplots(map_no)` - Lists all add plots for a given map
  - `get_addplot(map_no, addplot_no)` - Retrieves specific add plot information
- Created test script `test_addplot_history.py` to demonstrate and test the new functionality
- Updated README.md with documentation and examples for the new features
- Bumped version from 0.2.0 to 0.3.0

This enhancement enables more sophisticated analysis workflows, such as comparing multiple
datasets against the same base map, tracking changes in data over time, and building a
history of analysis operations for better reproducibility.

fix #6