### PR TITLE
docs: diagnosticScore.distance 点単位フィールドの Reference Manual 反映と検証スクリプト追加 (#31)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -507,27 +507,35 @@ ds = result['diagnosticScore']
 per_point = ds['distance']['normalizedDistancesPerPoint']
 print(f"Max deviation: {max(per_point):.2f} × Rg at index {np.argmax(per_point)}")
 
-# Same value can be reproduced client-side from xyData since the basemap is centered
-# at the origin (see "Basemap Coordinate System" below):
+# Same value can be approximated client-side from xyData since the basemap is
+# centered near the origin (see "Basemap Coordinate System" below):
 xy = result['xyData']
 rg = ds['distance']['radiusOfGyration']
-reproduced = np.linalg.norm(xy, axis=1) / rg     # equals per_point (within float precision)
+approx = np.linalg.norm(xy, axis=1) / rg         # approx ≈ per_point, within ~1e-3 × Rg
 ```
 
 ### Basemap Coordinate System
 
 toorPIA basemaps are constructed so that **the centroid of the base point cloud
-coincides with the origin `(0, 0)`** of the resulting coordinate system. This
-centering is performed automatically during basemap construction and requires no
-user configuration. Two practical consequences:
+sits at or very near the origin `(0, 0)`** of the resulting coordinate system.
+This centering is performed automatically during basemap construction and
+requires no user configuration. A small numerical residual may remain — in
+practice the centroid offset is typically on the order of `1e-3 × radiusOfGyration`
+or smaller. Practical consequences:
 
-- `radiusOfGyration` equals the RMS distance of base points from the origin.
+- `radiusOfGyration` is, to a very close approximation, the RMS distance of base
+  points from the origin.
 - For any addplot point `(x_j, y_j)`, the distance from the base centroid is
-  simply `sqrt(x_j**2 + y_j**2)`, which lets client code reproduce
-  `distancesPerPoint` and `normalizedDistancesPerPoint` directly from `xyData`.
+  well approximated by `sqrt(x_j**2 + y_j**2)`. This lets client code estimate
+  `distancesPerPoint` and `normalizedDistancesPerPoint` directly from `xyData`,
+  with an absolute error bounded by the centroid offset magnitude.
 
-Use this property when you need per-point deviation but are working with an older
-server build that does not yet return the `*PerPoint` fields.
+For values that match the server's `distancesPerPoint` /
+`normalizedDistancesPerPoint` exactly (i.e. computed against the true centroid),
+read those fields directly from the addplot response. Use the
+`sqrt(x_j**2 + y_j**2)` approximation only when working with an older server
+build that does not yet return the `*PerPoint` fields, or when an absolute error
+of `~1e-3 × radiusOfGyration` is acceptable.
 
 ### addplot_waveform()
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -487,6 +487,48 @@ if ds:
     print(f"Distance ± std: {ds['distance']['meanDistance']:.4f} ± {ds['distance']['distanceStd']:.4f}")
 ```
 
+**Per-Point Distance Analysis:**
+
+When you submit multiple records in a single `addplot()` call, the aggregate fields
+(`meanDistance` / `normalizedDistance` / `distanceStd` / `exceedanceRatio`) summarize
+all M points. To inspect each point individually, use the per-point arrays:
+
+- `distancesPerPoint[j]` — Euclidean distance of point j from the basemap centroid.
+- `normalizedDistancesPerPoint[j]` — `distancesPerPoint[j] / radiusOfGyration`,
+  which is the per-point normalized deviation in units of Rg.
+
+```python
+import numpy as np
+
+result = client.addplot(df_add_30days, detabn_threshold=0.5, detabn_max_window=1)
+ds = result['diagnosticScore']
+
+# Per-point normalized deviation (one value per input record)
+per_point = ds['distance']['normalizedDistancesPerPoint']
+print(f"Max deviation: {max(per_point):.2f} × Rg at index {np.argmax(per_point)}")
+
+# Same value can be reproduced client-side from xyData since the basemap is centered
+# at the origin (see "Basemap Coordinate System" below):
+xy = result['xyData']
+rg = ds['distance']['radiusOfGyration']
+reproduced = np.linalg.norm(xy, axis=1) / rg     # equals per_point (within float precision)
+```
+
+### Basemap Coordinate System
+
+toorPIA basemaps are constructed so that **the centroid of the base point cloud
+coincides with the origin `(0, 0)`** of the resulting coordinate system. This
+centering is performed automatically during basemap construction and requires no
+user configuration. Two practical consequences:
+
+- `radiusOfGyration` equals the RMS distance of base points from the origin.
+- For any addplot point `(x_j, y_j)`, the distance from the base centroid is
+  simply `sqrt(x_j**2 + y_j**2)`, which lets client code reproduce
+  `distancesPerPoint` and `normalizedDistancesPerPoint` directly from `xyData`.
+
+Use this property when you need per-point deviation but are working with an older
+server build that does not yet return the `*PerPoint` fields.
+
 ### addplot_waveform()
 
 For WAV and CSV files, you can add waveform data to an existing map using the `addplot_waveform` method. This is particularly useful for acoustic monitoring, vibration analysis, and time-series anomaly detection.
@@ -755,13 +797,19 @@ Abnormality detection parameters:
             'identnaParams': { ... }    # identna parameters used
         },
         'distance': {
-            'meanDistance': 0.42,        # Mean distance from basemap centroid
-            'distanceStd': 0.08,         # Standard deviation of distances
-            'radiusOfGyration': 0.25,    # Basemap radius of gyration (Rg)
-            'normalizedDistance': 1.68,  # meanDistance / Rg
-            'exceedanceRatio': 0.35,     # Ratio of points exceeding 2×Rg
-            'threshold': 0.50,           # Distance threshold (2×Rg)
-            'status': 'warning'          # Distance judgment
+            'meanDistance': 0.42,         # Mean distance from basemap centroid
+            'distanceStd': 0.08,          # Standard deviation of distances
+            'radiusOfGyration': 0.25,     # Basemap radius of gyration (Rg)
+            'normalizedDistance': 1.68,   # meanDistance / Rg (aggregate, length M average)
+            'exceedanceRatio': 0.35,      # Ratio of points exceeding 2×Rg
+            'threshold': 0.50,            # Distance threshold (2×Rg)
+            'status': 'warning',          # Distance judgment
+            'distancesPerPoint': [        # Per-point distances from basemap centroid (length = M)
+                0.40, 0.43, 0.42, ...
+            ],
+            'normalizedDistancesPerPoint': [  # Per-point normalized distance = d_j / Rg (length = M)
+                1.60, 1.72, 1.68, ...
+            ]
         },
         'compositeStatus': 'warning'  # Combined: 'normal', 'warning', or 'danger'
     },

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -517,22 +517,25 @@ approx = np.linalg.norm(xy, axis=1) / rg         # approx ≈ per_point, within 
 ### Basemap Coordinate System
 
 toorPIA basemaps are constructed so that **the centroid of the base point cloud
-sits at or very near the origin `(0, 0)`** of the resulting coordinate system.
-This centering is performed automatically during basemap construction and
-requires no user configuration. A small numerical residual may remain — in
-practice the centroid offset is typically on the order of `1e-3 × radiusOfGyration`
-or smaller. Practical consequences:
+is placed at the origin `(0, 0)`** in the engine's double-precision internal
+evaluation. The persisted coordinate file `xy.dat` — which is the source of the
+`xyData` field returned to clients and is also the input that addplot uses to
+evaluate new points — is written with approximately 4 decimal digits of
+precision. This output rounding introduces a small numerical residual in the
+observable centroid, typically on the order of `1e-3 × radiusOfGyration` or
+smaller. Practical consequences:
 
 - `radiusOfGyration` is, to a very close approximation, the RMS distance of base
   points from the origin.
-- For any addplot point `(x_j, y_j)`, the distance from the base centroid is
-  well approximated by `sqrt(x_j**2 + y_j**2)`. This lets client code estimate
-  `distancesPerPoint` and `normalizedDistancesPerPoint` directly from `xyData`,
-  with an absolute error bounded by the centroid offset magnitude.
+- Server-side `distancesPerPoint` / `normalizedDistancesPerPoint` are computed
+  in the same `xy.dat` coordinate system that addplot uses, so they are exact
+  values within that system — not approximations.
+- For any addplot point `(x_j, y_j)`, the server's `distancesPerPoint[j]` is
+  well approximated by `sqrt(x_j**2 + y_j**2)`, with an absolute error bounded
+  by the centroid offset described above.
 
-For values that match the server's `distancesPerPoint` /
-`normalizedDistancesPerPoint` exactly (i.e. computed against the true centroid),
-read those fields directly from the addplot response. Use the
+For exact per-point distances, read `distancesPerPoint` and
+`normalizedDistancesPerPoint` directly from the addplot response. Use the
 `sqrt(x_j**2 + y_j**2)` approximation only when working with an older server
 build that does not yet return the `*PerPoint` fields, or when an absolute error
 of `~1e-3 × radiusOfGyration` is acceptable.

--- a/samples/test_diagnostic_score_per_point.py
+++ b/samples/test_diagnostic_score_per_point.py
@@ -15,8 +15,9 @@ addplot を複数レコードまとめて呼び出した際に正しく返却さ
   1. 新フィールドの存在と型
   2. 配列長 = addplot 投入点数 M
   3. normalizedDistancesPerPoint[j] == distancesPerPoint[j] / radiusOfGyration
-  4. ベースマップ座標系仕様（重心=原点）:
-       distancesPerPoint[j] == sqrt(x_j² + y_j²)  (xyData の各行ノルム)
+  4. ベースマップ座標系仕様（重心 ≈ 原点）:
+       |sqrt(x_j² + y_j²) − distancesPerPoint[j]| / Rg が十分小さい
+       (=ベース重心が原点近傍にあることの間接確認)
   5. 集約値との整合:
        mean(distancesPerPoint) == meanDistance
        mean(normalizedDistancesPerPoint) == normalizedDistance
@@ -35,10 +36,22 @@ from toorpia import toorPIA
 ABS_TOL_6 = 5e-6
 ABS_TOL_4 = 5e-4
 
+# ベース重心が原点近傍にあることの相対許容（|G| / Rg の許容上限）
+# toorPIA エンジンは構築時に基本的に重心が原点に位置するよう規格化されるが、
+# 数値計算上の小さな残差 (実測例: ~5e-4 × Rg) を伴うため、絶対零ではなく
+# 相対許容で「原点近傍」性を検証する。
+CENTROID_REL_TOL = 1e-2
+
+
+# 検証結果を集約するためのリスト（全フェーズ共通）
+_failed = []
+
 
 def _check(label, ok, detail=""):
     mark = "✓" if ok else "✗"
     print(f"  {mark} {label}" + (f"  ({detail})" if detail else ""))
+    if not ok:
+        _failed.append(label)
     return ok
 
 
@@ -106,6 +119,8 @@ def main():
         print("   backend 側で toorpia/backend#93 の変更がデプロイされていない可能性があります")
         return 1
 
+
+
     M = len(add_data)
     _check(f"len(distancesPerPoint) == M ({M})",
            len(distances_pp) == M,
@@ -128,14 +143,22 @@ def main():
         f"max |Δ| = {max_diff:.2e}, tol = {ABS_TOL_4:.0e}",
     )
 
-    print("\n--- Phase 4: 座標系仕様 (重心=原点) の検証 ---")
+    print("\n--- Phase 4: 座標系仕様 (重心 ≈ 原点) の検証 ---")
     xy = result["xyData"]
-    norms = np.linalg.norm(xy, axis=1)
-    max_diff_origin = float(np.abs(norms - dpp).max())
+    norms_from_origin = np.linalg.norm(xy, axis=1)
+    max_diff_origin = float(np.abs(norms_from_origin - dpp).max())
+    rel_offset = max_diff_origin / rg if rg > 0 else float("inf")
+    print(f"  max |sqrt(x²+y²) − d_j|  = {max_diff_origin:.2e}")
+    print(f"  / radiusOfGyration       = {rel_offset:.2e}  (= ベース重心の原点からの実効距離 ÷ Rg の上限)")
     _check(
-        "distancesPerPoint[j] == sqrt(x_j² + y_j²)  (基本仕様: 重心=原点)",
-        max_diff_origin < ABS_TOL_6,
-        f"max |Δ| = {max_diff_origin:.2e}, tol = {ABS_TOL_6:.0e}",
+        f"重心が原点近傍にある (相対残差 < {CENTROID_REL_TOL:.0e} × Rg)",
+        rel_offset < CENTROID_REL_TOL,
+        f"observed = {rel_offset:.2e}",
+    )
+    print(
+        "  (注) この残差は toorPIA エンジンが構築時に重心を原点に揃える際の数値計算上の\n"
+        "       残差で、典型的には 1e-3 × Rg 程度です。点単位距離を厳密値で必要とする場合は\n"
+        "       diagnosticScore.distance.distancesPerPoint を参照してください。"
     )
 
     print("\n--- Phase 5: 集約値との整合 ---")
@@ -161,6 +184,14 @@ def main():
     print(f"  {'j':>3}  {'x':>10}  {'y':>10}  {'d_j':>10}  {'d_j / Rg':>10}")
     for j, ((x, y), d, n) in enumerate(zip(xy, dpp, npp)):
         print(f"  {j:>3}  {x:>10.4f}  {y:>10.4f}  {d:>10.4f}  {n:>10.4f}")
+
+    if _failed:
+        print(f"\n❌ 検証失敗: {len(_failed)} 件")
+        for label in _failed:
+            print(f"   - {label}")
+        if api.shareUrl:
+            print(f"  shareUrl: {api.shareUrl}")
+        return 1
 
     print("\n=== 検証完了: すべての項目を満たしました ===")
     if api.shareUrl:

--- a/samples/test_diagnostic_score_per_point.py
+++ b/samples/test_diagnostic_score_per_point.py
@@ -156,9 +156,11 @@ def main():
         f"observed = {rel_offset:.2e}",
     )
     print(
-        "  (注) この残差は toorPIA エンジンが構築時に重心を原点に揃える際の数値計算上の\n"
-        "       残差で、典型的には 1e-3 × Rg 程度です。点単位距離を厳密値で必要とする場合は\n"
-        "       diagnosticScore.distance.distancesPerPoint を参照してください。"
+        "  (注) toorPIA コアバイナリ内部 (倍精度) では重心を厳密に原点に揃えていますが、\n"
+        "       座標出力 (xy.dat) は下4桁程度の精度で書き出されるため、xy.dat ベースで\n"
+        "       観測される残差は典型的に 1e-3 × Rg 程度となります。addplot もこの xy.dat\n"
+        "       を入力として点単位距離を評価するため、server から返る distancesPerPoint\n"
+        "       はこの座標系における厳密値です（xyData との近似一致はその副産物）。"
     )
 
     print("\n--- Phase 5: 集約値との整合 ---")

--- a/samples/test_diagnostic_score_per_point.py
+++ b/samples/test_diagnostic_score_per_point.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+toorPIA diagnosticScore 点単位フィールド検証スクリプト
+
+backend issue toorpia/backend#93 / client issue toorpia/toorpia#31 で
+追加された diagnosticScore.distance の点単位フィールド
+(`distancesPerPoint`, `normalizedDistancesPerPoint`) が、
+addplot を複数レコードまとめて呼び出した際に正しく返却され、
+かつ既存集約値および xyData との数値整合が取れていることを検証する。
+
+使用方法:
+    python test_diagnostic_score_per_point.py
+
+検証項目:
+  1. 新フィールドの存在と型
+  2. 配列長 = addplot 投入点数 M
+  3. normalizedDistancesPerPoint[j] == distancesPerPoint[j] / radiusOfGyration
+  4. ベースマップ座標系仕様（重心=原点）:
+       distancesPerPoint[j] == sqrt(x_j² + y_j²)  (xyData の各行ノルム)
+  5. 集約値との整合:
+       mean(distancesPerPoint) == meanDistance
+       mean(normalizedDistancesPerPoint) == normalizedDistance
+"""
+
+import sys
+
+import numpy as np
+import pandas as pd
+from toorpia import toorPIA
+
+
+# 丸めを考慮した許容誤差
+# - distancesPerPoint は toFixed(6) で丸められて返却される
+# - normalizedDistancesPerPoint は toFixed(4) で丸められる
+ABS_TOL_6 = 5e-6
+ABS_TOL_4 = 5e-4
+
+
+def _check(label, ok, detail=""):
+    mark = "✓" if ok else "✗"
+    print(f"  {mark} {label}" + (f"  ({detail})" if detail else ""))
+    return ok
+
+
+def main():
+    print("=== toorPIA diagnosticScore 点単位フィールド検証 ===\n")
+
+    # データ読み込み
+    try:
+        base_data = pd.read_csv("biopsy.csv").drop(columns=["No", "ID", "Diagnosis"])
+        add_data = pd.read_csv("biopsy-add.csv").drop(columns=["No", "ID", "Diagnosis"])
+    except FileNotFoundError as e:
+        print(f"❌ {e}\n   biopsy.csv / biopsy-add.csv が見つかりません。samples ディレクトリで実行してください。")
+        return 1
+    print(f"  base_data: {base_data.shape}")
+    print(f"  add_data : {add_data.shape}  (M = {len(add_data)} 点を一括投入)")
+
+    # ベースマップ作成 + addplot
+    api = toorPIA()
+    api.fit_transform(
+        base_data,
+        label="diagnosticScore per-point validation",
+        description="Validate distancesPerPoint / normalizedDistancesPerPoint fields",
+    )
+    print(f"\n  mapNo = {api.mapNo}")
+
+    print("\n--- Phase 1: addplot 実行 ---")
+    result = api.addplot(
+        add_data,
+        detabn_max_window=1,
+        detabn_threshold=0.5,
+        detabn_rate_threshold=1.0,
+        detabn_print_score=True,
+    )
+    if result is None:
+        print("❌ addplot 失敗")
+        return 1
+    print(f"  addPlotNo            = {result['addPlotNo']}")
+    print(f"  abnormalityStatus    = {result['abnormalityStatus']}")
+    print(f"  xyData.shape         = {result['xyData'].shape}")
+
+    ds = result.get("diagnosticScore")
+    if not ds:
+        print("❌ diagnosticScore がレスポンスに含まれていません")
+        return 1
+
+    distance = ds.get("distance")
+    if not distance:
+        print("❌ diagnosticScore.distance がレスポンスに含まれていません")
+        return 1
+
+    # 検証
+    print("\n--- Phase 2: フィールド存在と型の確認 ---")
+    distances_pp = distance.get("distancesPerPoint")
+    normalized_pp = distance.get("normalizedDistancesPerPoint")
+    failures = []
+
+    if not _check("distancesPerPoint がレスポンスに存在",
+                  distances_pp is not None and isinstance(distances_pp, list)):
+        failures.append("distancesPerPoint missing")
+    if not _check("normalizedDistancesPerPoint がレスポンスに存在",
+                  normalized_pp is not None and isinstance(normalized_pp, list)):
+        failures.append("normalizedDistancesPerPoint missing")
+    if failures:
+        print(f"\n❌ 必須フィールド欠落: {failures}")
+        print("   backend 側で toorpia/backend#93 の変更がデプロイされていない可能性があります")
+        return 1
+
+    M = len(add_data)
+    _check(f"len(distancesPerPoint) == M ({M})",
+           len(distances_pp) == M,
+           f"got {len(distances_pp)}")
+    _check(f"len(normalizedDistancesPerPoint) == M ({M})",
+           len(normalized_pp) == M,
+           f"got {len(normalized_pp)}")
+
+    print("\n--- Phase 3: 内部整合 (normalized = distance / Rg) ---")
+    rg = distance["radiusOfGyration"]
+    print(f"  radiusOfGyration (Rg) = {rg:.6f}")
+    dpp = np.asarray(distances_pp, dtype=float)
+    npp = np.asarray(normalized_pp, dtype=float)
+
+    expected_npp = dpp / rg if rg > 0 else np.zeros_like(dpp)
+    max_diff = float(np.abs(expected_npp - npp).max())
+    _check(
+        "normalizedDistancesPerPoint[j] == distancesPerPoint[j] / Rg",
+        max_diff < ABS_TOL_4,
+        f"max |Δ| = {max_diff:.2e}, tol = {ABS_TOL_4:.0e}",
+    )
+
+    print("\n--- Phase 4: 座標系仕様 (重心=原点) の検証 ---")
+    xy = result["xyData"]
+    norms = np.linalg.norm(xy, axis=1)
+    max_diff_origin = float(np.abs(norms - dpp).max())
+    _check(
+        "distancesPerPoint[j] == sqrt(x_j² + y_j²)  (基本仕様: 重心=原点)",
+        max_diff_origin < ABS_TOL_6,
+        f"max |Δ| = {max_diff_origin:.2e}, tol = {ABS_TOL_6:.0e}",
+    )
+
+    print("\n--- Phase 5: 集約値との整合 ---")
+    mean_d = float(distance["meanDistance"])
+    mean_nd = float(distance["normalizedDistance"])
+    print(f"  meanDistance       (server) = {mean_d:.6f}")
+    print(f"  mean(distancesPerPoint)     = {dpp.mean():.6f}")
+    print(f"  normalizedDistance (server) = {mean_nd:.4f}")
+    print(f"  mean(normalizedDistancesPerPoint) = {npp.mean():.4f}")
+
+    _check(
+        "mean(distancesPerPoint) == meanDistance",
+        abs(dpp.mean() - mean_d) < ABS_TOL_6,
+        f"|Δ| = {abs(dpp.mean() - mean_d):.2e}",
+    )
+    _check(
+        "mean(normalizedDistancesPerPoint) == normalizedDistance",
+        abs(npp.mean() - mean_nd) < ABS_TOL_4,
+        f"|Δ| = {abs(npp.mean() - mean_nd):.2e}",
+    )
+
+    print("\n--- Phase 6: 点単位スコア一覧（参考表示） ---")
+    print(f"  {'j':>3}  {'x':>10}  {'y':>10}  {'d_j':>10}  {'d_j / Rg':>10}")
+    for j, ((x, y), d, n) in enumerate(zip(xy, dpp, npp)):
+        print(f"  {j:>3}  {x:>10.4f}  {y:>10.4f}  {d:>10.4f}  {n:>10.4f}")
+
+    print("\n=== 検証完了: すべての項目を満たしました ===")
+    if api.shareUrl:
+        print(f"  shareUrl: {api.shareUrl}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- backend toorpia/backend#94 (issue #93) で `diagnosticScore.distance` に追加された点単位フィールド `distancesPerPoint` / `normalizedDistancesPerPoint` を Python クライアントの API Reference Manual に反映 (closes #31)
- ベースマップ座標系の仕様 (コアエンジン内部で重心=原点、xy.dat 出力で ~1e-3 × Rg の残差) を Reference Manual に新節として明文化
- 新フィールドおよび座標系仕様を検証するエンドツーエンドのサンプルスクリプトを `samples/` に追加

## 変更内容

### `docs/api-reference.md`

- **Return Values** 節: `addplot` 返り値の `distance` ブロックに `distancesPerPoint` / `normalizedDistancesPerPoint` を追記
- **`addplot()` の Composite Diagnostic Score** 節: `Per-Point Distance Analysis` サブセクションを新設し、点単位値の利用方法と `xyData` からの近似計算法を提示
- **Basemap Coordinate System** 節を新設:
  - コアエンジン内部 (倍精度) では重心が原点に厳密配置されること
  - `xy.dat` は下4桁程度の精度で書き出されるため、xy.dat ベースで `~1e-3 × radiusOfGyration` の残差が観測されること
  - addplot はこの xy.dat を入力に用いるため、サーバ返却の `distancesPerPoint` は xy.dat 座標系における厳密値であり、`xyData` から手元で計算する近似値より優先すべきこと

### `samples/test_diagnostic_score_per_point.py` (新規)

`biopsy.csv` (683点) + `biopsy-add.csv` (9点) を入力に、以下6フェーズで検証する E2E テスト:

1. addplot 実行
2. `distancesPerPoint` / `normalizedDistancesPerPoint` の存在と長さ (= M)
3. `normalizedDistancesPerPoint[j] == distancesPerPoint[j] / Rg`  (内部整合)
4. xy.dat 座標系における重心 ≈ 原点の検証 (相対残差 < 1e-2 × Rg)
5. `mean(distancesPerPoint) == meanDistance` および `mean(normalizedDistancesPerPoint) == normalizedDistance` (集約整合)
6. 点単位スコア一覧の参考表示

新フィールドが返却されない (旧 backend) 場合は明示的に「toorpia/backend#93 がデプロイされていない可能性があります」と表示する。

## 後方互換性

- ドキュメント追記のみで Python 側コードに破壊的変更なし
- 新サンプルスクリプトは backend toorpia/backend#94 がデプロイされた環境でのみ全フェーズ ✓ となる (旧 backend では Phase 2 で明示的失敗)

## Test plan

実機環境 (v0.0.8-port443_9001) で `samples/test_diagnostic_score_per_point.py` を実行し、以下を確認済み:

- [x] Phase 1: addplot 成功 (status=abnormal, xyData.shape=(9,2))
- [x] Phase 2: 新フィールド存在、長さ = M (= 9)
- [x] Phase 3: max |Δ| = 4.69e-05 < tol 5e-04
- [x] Phase 4: 相対残差 5.66e-04 < tol 1e-2
- [x] Phase 5: |Δ| = 2.22e-07 / 4.44e-05
- [x] Phase 6: 点単位スコア表示

## 依存関係

- backend 側 PR toorpia/backend#94 (issue #93) のマージ・デプロイが前提
- Closes #31
