### PR TITLE
feat: embedding系統メソッド basemap_embedding / addplot_embedding を追加 (v1.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,51 @@ else:
 print(f"🌐 View Analysis: {test_result['shareUrl']}")
 ```
 
+## Embedding Data Analysis
+
+### Step 1: Create Base Map from Embedding Vectors
+
+```python
+import numpy as np
+
+# Direct ndarray input (rows = samples, columns = embedding dimensions)
+embeddings = np.load("sentence_embeddings.npy")  # e.g. shape (1000, 768)
+result = client.basemap_embedding(
+    embeddings,
+    label="Sentence Embedding Baseline",
+    tag="NLP Monitoring"
+)
+
+# Or use a CSV file (leading non-numeric columns are auto-detected as ID columns)
+result = client.basemap_embedding("image_features.csv")
+
+print(f"✅ Embedding base map created!")
+print(f"Map Number: {result['mapNo']}")
+print(f"🌐 View Map: {result['shareUrl']}")
+```
+
+**Tip:** Each vector is L2-normalized by default. For embeddings whose norm carries information, pass `l2_normalization=False`. Note that `vector_normalization` is not applicable to embedding maps — the engine always uses the euclidean distance mode.
+
+### Step 2: Detect Embedding Anomalies
+
+```python
+# Test new embeddings against the latest basemap
+# (preprocessing options are inherited from the basemap automatically)
+new_embeddings = np.load("new_embeddings.npy")
+test_result = client.addplot_embedding(new_embeddings)
+
+# Or test against a specific previous basemap
+test_result = client.addplot_embedding(new_embeddings, mapNo=789)
+
+if test_result['abnormalityStatus'] == 'abnormal':
+    print(f"🚨 Embedding anomaly detected!")
+    print(f"Abnormality Score: {test_result['abnormalityScore']:.3f}")
+else:
+    print(f"✅ Embedding pattern is normal")
+
+print(f"🌐 View Analysis: {test_result['shareUrl']}")
+```
+
 ## Visual Analysis with Map Inspector
 
 All basemap and addplot operations generate interactive visualizations accessible through share URLs.
@@ -278,6 +323,7 @@ print(f"Anomaly status: {addplot_result['abnormalityStatus']}")
 - **DataFrame Processing**: Direct processing of pandas/numpy data
 - **CSV Direct Processing**: Memory-efficient processing of large files
 - **Audio Processing**: FFT feature extraction from WAV/CSV files
+- **Embedding Processing**: Direct analysis of embedding vectors (CSV/numpy/pandas)
 
 ### Anomaly Detection
 - Learning normal data patterns

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,8 +8,10 @@ This document provides detailed specifications for all methods and parameters of
 - [Core API Methods](#core-api-methods)
   - [basemap_csvform()](#basemap_csvform) - CSV basemap creation
   - [basemap_waveform()](#basemap_waveform) - Audio basemap creation  
+  - [basemap_embedding()](#basemap_embedding) - Embedding basemap creation
   - [addplot_csvform()](#addplot_csvform) - CSV anomaly detection
   - [addplot_waveform()](#addplot_waveform) - Audio anomaly detection
+  - [addplot_embedding()](#addplot_embedding) - Embedding anomaly detection
 - [Alternative Methods](#alternative-methods)
   - [fit_transform()](#fit_transform) - DataFrame-based processing
   - [addplot()](#addplot) - DataFrame-based anomaly detection
@@ -168,6 +170,59 @@ print(f"Share URL: {client.shareUrl}")
 
 **Returns:** Dictionary with `xyData`, `mapNo`, and `shareUrl`
 
+### basemap_embedding()
+
+Creates a base map from embedding vectors (LLM embeddings, image features, etc.), establishing normal data patterns for anomaly detection. Accepts CSV files or in-memory data (2D numpy.ndarray / pandas.DataFrame).
+
+```python
+import numpy as np
+
+# Direct ndarray input (rows = samples, columns = embedding dimensions)
+embeddings = np.load("sentence_embeddings.npy")  # e.g. shape (1000, 768)
+result = client.basemap_embedding(
+    embeddings,
+    label="Sentence Embedding Baseline",
+    tag="NLP Monitoring"
+)
+
+# CSV file input (leading non-numeric columns are auto-detected as ID columns)
+result = client.basemap_embedding(
+    "image_features.csv",   # e.g. filename column + 768 feature columns
+    label="Image Feature Baseline"
+)
+
+# Embeddings whose norm carries information: disable L2 normalization
+result = client.basemap_embedding(
+    "embeddings.csv",
+    l2_normalization=False
+)
+
+# ID columns that look numeric: specify their count explicitly
+result = client.basemap_embedding(
+    "embeddings_with_numeric_ids.csv",
+    id_columns=1
+)
+
+# Access results with unified structure
+print(f"Map Number: {result['mapNo']}")
+print(f"Coordinates shape: {result['xyData'].shape}")
+print(f"View online: {result['shareUrl']}")
+```
+
+**Parameters:**
+- `files` (str, list, numpy.ndarray or pandas.DataFrame): CSV file path(s) or in-memory embedding data. Rows are samples, columns are embedding dimensions. Header rows are auto-detected; leading non-numeric columns are auto-detected as ID/label columns. An ndarray is uploaded as a headerless CSV (dimension names are auto-generated); a DataFrame keeps its header.
+- `l2_normalization` (bool, optional): Enable/disable L2 normalization of each input vector. Default server-side is `True`. Pass `False` for embeddings whose norm carries information.
+- `id_columns` (int, optional): Number of leading ID/label columns. Usually unnecessary (auto-detected); set only when the ID columns look numeric.
+- `label`, `tag`, `description` (str): Metadata for map identification
+- `identna_resolution` (int): Analysis mesh resolution (default: 100)
+- `identna_effective_radius` (float or "auto"): Analysis radius ratio (default: 0.1)
+- `identna_er_method` (str): Bandwidth method when effective_radius="auto": "silverman" (default) or "knn"
+- `identna_knn_k` (int): k for knn method (0 = auto ceil(sqrt(n)))
+
+**Note:** `vector_normalization` is not applicable to embedding maps — the engine always uses the euclidean distance mode for embedding data.
+
+**Returns:** Dictionary with `xyData`, `mapNo`, and `shareUrl`
+
 ### addplot_csvform()
 
 Tests new CSV data against an existing CSV-based map for anomaly detection. Automatically inherits processing parameters from the base map.
@@ -260,6 +315,43 @@ print(f"Acoustic analysis #{result['addPlotNo']} completed")
 - **Multi-format support**: Handles WAV files and CSV time-series data
 
 **Returns:** Dictionary with acoustic anomaly detection results and composite diagnostic score
+
+### addplot_embedding()
+
+Tests new embedding data against an existing embedding-based map for anomaly detection. Preprocessing options (`l2_normalization`, `id_columns`) are automatically inherited from the base map and cannot be specified manually.
+
+```python
+import numpy as np
+
+# Test new embeddings against the most recent base map
+new_embeddings = np.load("new_embeddings.npy")
+result = client.addplot_embedding(new_embeddings)
+
+# Test against a specific base map
+result = client.addplot_embedding("new_features.csv", mapNo=123)
+
+# Advanced anomaly detection parameters
+result = client.addplot_embedding(
+    new_embeddings,
+    detabn_max_window=5,         # Anomaly detection window
+    detabn_rate_threshold=0.8,   # Anomaly rate threshold
+    detabn_threshold=0.1,        # Normal area threshold
+    detabn_print_score=True      # Include detailed scores
+)
+
+# Analyze results
+print(f"Status: {result['abnormalityStatus']}")  # 'normal', 'abnormal', 'unknown'
+print(f"Score: {result['abnormalityScore']}")
+print(f"Data points analyzed: {result['xyData'].shape[0]}")
+print(f"View results: {result['shareUrl']}")
+```
+
+**Key Features:**
+- **Automatic consistency**: `l2_normalization`, `id_columns` and dimension names are inherited from the base map; specifying preprocessing options here is rejected by the server
+- **Dimension validation**: Processing fails with a clear error when the dimension count differs from the base map
+- **Flexible input**: CSV file path(s), 2D numpy.ndarray, or pandas.DataFrame (same conventions as `basemap_embedding()`)
+
+**Returns:** Dictionary with anomaly detection results, coordinate data, and composite diagnostic score
 
 ---
 
@@ -756,7 +848,7 @@ features = client.get_addplot_features(map_no=123, addplot_no=1)
 df = client.to_dataframe(features)
 ```
 
-**Important**: Feature analysis is only supported for DataFrame and CSV-based maps. This function is **not available for waveform-based maps** due to technical limitations.
+**Important**: Feature analysis is only supported for DataFrame and CSV-based maps. This function is **not available for waveform-based or embedding-based maps** due to technical limitations.
 
 ---
 
@@ -779,6 +871,15 @@ Abnormality detection parameters:
 - **detabn_rate_threshold** (float, default=1.0): Lower threshold for abnormality rate (0.0 < rate <= 1.0). If rate >= threshold, data is considered abnormal
 - **detabn_threshold** (int/float, default=0): Threshold for relative normal area value. If value > threshold, the point is considered normal
 - **detabn_print_score** (bool, default=True): Whether to include detailed score information in the analysis
+
+### Embedding Preprocessing Parameters
+
+Embedding preprocessing parameters, accepted by `basemap_embedding()` only. `addplot_embedding()` automatically inherits them from the base map and rejects manual specification.
+
+- **l2_normalization** (bool, default=True): L2-normalize each input vector to a unit vector before mapping. Pass `False` for embeddings whose norm carries information.
+- **id_columns** (int, default=None): Number of leading ID/label columns to pass through. When unspecified, leading non-numeric columns are auto-detected. Set explicitly only when the ID columns look numeric.
+
+Note: `vector_normalization` is not applicable to embedding maps — the engine always uses the euclidean distance mode for embedding data.
 
 ---
 
@@ -845,13 +946,14 @@ toorPIA enforces strict compatibility between base map creation methods and addp
 
 ### Compatibility Matrix
 
-| Base Map Method | addplot() | addplot_csvform() | addplot_waveform() |
-|---|:---:|:---:|:---:|
-| **basemap_csvform()** | ❌ | ✅ | ❌ |
-| **basemap_waveform()** | ❌ | ❌ | ✅ |
-| **fit_transform()** | ✅ | ❌ | ❌ |
-| **fit_transform_csvform()** | ❌ | ✅ | ❌ |
-| **fit_transform_waveform()** | ❌ | ❌ | ✅ |
+| Base Map Method | addplot() | addplot_csvform() | addplot_waveform() | addplot_embedding() |
+|---|:---:|:---:|:---:|:---:|
+| **basemap_csvform()** | ❌ | ✅ | ❌ | ❌ |
+| **basemap_waveform()** | ❌ | ❌ | ✅ | ❌ |
+| **basemap_embedding()** | ❌ | ❌ | ❌ | ✅ |
+| **fit_transform()** | ✅ | ❌ | ❌ | ❌ |
+| **fit_transform_csvform()** | ❌ | ✅ | ❌ | ❌ |
+| **fit_transform_waveform()** | ❌ | ❌ | ✅ | ❌ |
 
 ### Supported Processing Methods
 
@@ -870,17 +972,24 @@ toorPIA enforces strict compatibility between base map creation methods and addp
    - Addplot: Uses WAV/CSV files with FFT-based feature extraction
    - Use case: Audio analysis, vibration monitoring
 
+4. **Embedding Processing** (`basemap_embedding` + `addplot_embedding`)
+   - Base map: Created from embedding vectors (CSV files or numpy/pandas data)
+   - Addplot: Uses embedding data with preprocessing inherited from the base map
+   - Use case: LLM/image embedding monitoring, representation drift detection
+
 ### Compatibility Rules
 
 **✅ Compatible Combinations:**
 - DataFrame base map → `addplot()` method
 - CSV base map → `addplot_csvform()` method
 - Waveform base map → `addplot_waveform()` method
+- Embedding base map → `addplot_embedding()` method
 
 **❌ Incompatible Combinations:**
-- DataFrame base map → `addplot_csvform()` or `addplot_waveform()`
-- CSV base map → `addplot()` or `addplot_waveform()`
-- Waveform base map → `addplot()` or `addplot_csvform()`
+- DataFrame base map → `addplot_csvform()`, `addplot_waveform()` or `addplot_embedding()`
+- CSV base map → `addplot()`, `addplot_waveform()` or `addplot_embedding()`
+- Waveform base map → `addplot()`, `addplot_csvform()` or `addplot_embedding()`
+- Embedding base map → `addplot()`, `addplot_csvform()` or `addplot_waveform()`
 
 ### Error Messages
 

--- a/samples/test_addplot_history.py
+++ b/samples/test_addplot_history.py
@@ -62,7 +62,7 @@ def main():
         add_result_1 = client.addplot(add_data)
         print(f"First add plot created. Add Plot No: {client.currentAddPlotNo}")
         print(f"Share URL: {client.shareUrl}")
-        print(f"Result shape: {add_result_1.shape}\n")
+        print(f"Result shape: {add_result_1['xyData'].shape}\n")
     except Exception as e:
         print(f"Error creating first add plot: {str(e)}")
         return 1
@@ -73,7 +73,7 @@ def main():
         add_result_2 = client.addplot(add_data)
         print(f"Second add plot created. Add Plot No: {client.currentAddPlotNo}")
         print(f"Share URL: {client.shareUrl}")
-        print(f"Result shape: {add_result_2.shape}\n")
+        print(f"Result shape: {add_result_2['xyData'].shape}\n")
     except Exception as e:
         print(f"Error creating second add plot: {str(e)}")
         return 1

--- a/samples/test_basemap_embedding.py
+++ b/samples/test_basemap_embedding.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Example: Using the basemap_embedding / addplot_embedding API for embedding vectors
+
+This example generates synthetic embeddings with numpy (no data files needed),
+creates a base map with basemap_embedding(), and tests new data against it with
+addplot_embedding(). Embedding preprocessing (L2 normalization, ID column
+detection) is handled server-side; addplot inherits the basemap's settings
+automatically, so no preprocessing options are needed (or allowed) on addplot.
+
+The API key is taken from the TOORPIA_API_KEY environment variable
+(and the server URL from TOORPIA_API_URL for on-premise environments).
+"""
+import numpy as np
+from toorpia import toorPIA
+
+
+def main():
+    # Initialize client (uses TOORPIA_API_KEY / TOORPIA_API_URL environment variables)
+    client = toorPIA()
+
+    # Generate synthetic embeddings: 200 samples x 32 dimensions for the base map
+    rng = np.random.default_rng(42)
+    base_embeddings = rng.normal(size=(200, 32))
+    print(f"Base embeddings shape: {base_embeddings.shape}")
+
+    # New data for addplot: 50 samples from the same distribution,
+    # plus 10 shifted samples that should look anomalous
+    normal_add = rng.normal(size=(50, 32))
+    shifted_add = rng.normal(loc=3.0, size=(10, 32))
+    add_embeddings = np.vstack([normal_add, shifted_add])
+    print(f"Addplot embeddings shape: {add_embeddings.shape}")
+
+    # === Step 1: Create base map from the embedding vectors ===
+    # ndarray input is uploaded as a headerless CSV; dimension names are
+    # auto-generated server-side and stay consistent between basemap and addplot.
+    print("\n=== Creating embedding base map ===")
+    result = client.basemap_embedding(
+        base_embeddings,
+        label="Synthetic Embedding Baseline",
+        tag="Embedding Demo",
+        description="200 x 32 synthetic normal embeddings"
+    )
+    if result is None:
+        print("❌ Base map creation failed")
+        return
+    print(f"✅ Base map created!")
+    print(f"Map Number: {result['mapNo']}")
+    print(f"Coordinate Data Shape: {result['xyData'].shape}")
+    print(f"Share URL: {result['shareUrl']}")
+
+    # === Step 2: Add new embeddings for anomaly detection ===
+    # l2_normalization / id_columns must NOT be specified here:
+    # they are inherited from the basemap on the server side.
+    print("\n=== Adding embeddings for anomaly detection ===")
+    addplot_result = client.addplot_embedding(
+        add_embeddings,
+        detabn_max_window=5,
+        detabn_rate_threshold=1.0,
+        detabn_threshold=0,
+        detabn_print_score=True
+    )
+    if addplot_result is None:
+        print("❌ Addplot failed")
+        return
+    print(f"✅ Addplot completed!")
+    print(f"Addplot Number: {addplot_result['addPlotNo']}")
+    print(f"Addplot Data Shape: {addplot_result['xyData'].shape}")
+    print(f"Abnormality Status: {addplot_result['abnormalityStatus']}")
+    if addplot_result.get('abnormalityScore') is not None:
+        print(f"Abnormality Score: {addplot_result['abnormalityScore']:.4f}")
+    print(f"Updated Share URL: {addplot_result['shareUrl']}")
+
+    # Visual analysis instructions
+    print(f"\n🌐 Open in browser for visual analysis:")
+    print(f"   {addplot_result['shareUrl']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='toorpia',
-    version='1.1.1',
+    version='1.2.0',
     author='toor Inc.',
     author_email='takaeda@toor.jpn.com',
     description='API Frontend libraries of toorpia',

--- a/toorpia/client.py
+++ b/toorpia/client.py
@@ -991,6 +991,176 @@ class toorPIA:
                     pass
 
     @pre_authentication
+    def addplot_embedding(self, files, mapNo=None,
+                         # identna parameters
+                         identna_resolution=None, identna_effective_radius=None,
+                         identna_er_method=None, identna_knn_k=None,
+                         # detabn parameters
+                         detabn_max_window=5, detabn_rate_threshold=1.0,
+                         detabn_threshold=0, detabn_print_score=True):
+        """
+        Process embedding data for addplot (additional plot) analysis
+
+        Preprocessing options (l2_normalization, id_columns) are automatically
+        inherited from the base map on the server side and cannot be specified
+        here. This guarantees that basemap and addplot use identical
+        preprocessing and consistent dimension names.
+
+        Accepts CSV file path(s) or in-memory embedding data (2D numpy.ndarray
+        or pandas.DataFrame), with the same CSV conversion conventions as
+        basemap_embedding().
+
+        Args:
+            files (str, list, numpy.ndarray or pandas.DataFrame): CSV file path(s) or in-memory embedding data
+            mapNo (int, optional): Target map number. If None, uses current mapNo
+            identna_resolution (int, optional): Custom resolution for identna
+            identna_effective_radius (float or "auto", optional): Custom effective radius. "auto" for automatic determination
+            identna_er_method (str, optional): Bandwidth method when effective_radius="auto": "silverman" (default) or "knn"
+            identna_knn_k (int, optional): k for knn method (0 = auto ceil(sqrt(n)))
+            detabn_max_window (int): Maximum window size for abnormality detection
+            detabn_rate_threshold (float): Rate threshold for abnormality detection
+            detabn_threshold (int): Threshold value for abnormality detection
+            detabn_print_score (bool): Whether to print abnormality score
+
+        Returns:
+            dict: Dictionary containing:
+                - xyData: Coordinate data as NumPy array (each row is [x, y])
+                - addPlotNo: Additional plot number
+                - abnormalityStatus: 'normal', 'abnormal', or 'unknown'
+                - abnormalityScore: Abnormality score (float or None)
+                - diagnosticScore: Composite diagnostic score (dict or None), containing:
+                    - detabn: detabn evaluation details (normalityScore, abnormalityScore, status, params, identnaParams)
+                    - distance: Distance analysis (meanDistance, distanceStd, radiusOfGyration, normalizedDistance, exceedanceRatio, threshold, status)
+                    - compositeStatus: Combined status ('normal', 'warning', 'danger')
+                - shareUrl: Share URL for the map with this addplot
+        """
+        # Determine target map number
+        target_mapNo = mapNo if mapNo is not None else self.mapNo
+        if target_mapNo is None:
+            print("Error: Map number is not specified. Please provide mapNo or use basemap_embedding() first.")
+            return None
+
+        # ndarray/DataFrame direct input: convert to a temporary CSV file
+        temp_csv_path = None
+        if not isinstance(files, (str, list)):
+            temp_csv_path = self._convert_inmemory_embedding(files)
+            if temp_csv_path is None:
+                return None
+            files = [temp_csv_path]
+
+        # File existence and format check (accept both string and list, same as csvform)
+        if isinstance(files, str):
+            files = [files]  # Convert single file to list
+
+        if not files or not isinstance(files, list):
+            print("Error: files must be a file path (string) or list of file paths")
+            return None
+
+        files_to_upload = []
+        for file_path in files:
+            if not os.path.exists(file_path):
+                print(f"Error: File not found: {file_path}")
+                return None
+
+            # File format check (.csv only)
+            ext = os.path.splitext(file_path)[1].lower()
+            if ext != '.csv':
+                print(f"Error: Unsupported file format: {ext}. Only .csv files are supported.")
+                return None
+
+            files_to_upload.append(('files', open(file_path, 'rb')))
+
+        try:
+            # Prepare identna parameters
+            identna_params = {}
+            if identna_resolution is not None:
+                identna_params['resolution'] = int(identna_resolution)
+            if identna_effective_radius is not None:
+                identna_params['effectiveRadius'] = identna_effective_radius if identna_effective_radius == 'auto' else float(identna_effective_radius)
+            if identna_er_method is not None:
+                identna_params['erMethod'] = identna_er_method
+            if identna_knn_k is not None:
+                identna_params['knnK'] = int(identna_knn_k)
+
+            # Prepare detabn parameters
+            detabn_params = {
+                'maxWindow': int(detabn_max_window),
+                'rateThreshold': float(detabn_rate_threshold),
+                'threshold': int(detabn_threshold),
+                'printScore': bool(detabn_print_score)
+            }
+
+            # Send as form-data
+            form_data = {
+                'mapNo': str(target_mapNo),
+                'detabn_options': json.dumps(detabn_params)
+            }
+            if identna_params:
+                form_data['identna_options'] = json.dumps(identna_params)
+
+            headers = {'session-key': self.session_key}  # Content-Type is auto-set by requests
+            response = requests.post(
+                f"{API_URL}/data/addplot_embedding",
+                files=files_to_upload,
+                data=form_data,
+                headers=headers
+            )
+
+            if response.status_code == 200:
+                response_data = response.json()
+                addXyData = response_data['resdata']
+                self.currentAddPlotNo = response_data.get('addPlotNo')  # Save addplot number
+                self.shareUrl = response_data.get('shareUrl')  # Save share URL
+
+                # Convert coordinate data to NumPy array
+                np_array = np.array(addXyData)
+
+                # Return extended result with coordinate data and abnormality information
+                result = {
+                    'xyData': np_array,
+                    'addPlotNo': self.currentAddPlotNo,
+                    'abnormalityStatus': response_data.get('abnormalityStatus'),  # 'normal', 'abnormal', 'unknown'
+                    'abnormalityScore': response_data.get('abnormalityScore'),    # Abnormality score
+                    'diagnosticScore': response_data.get('diagnosticScore'),     # Composite diagnostic score
+                    'shareUrl': self.shareUrl
+                }
+
+                return result
+            elif response.status_code == 400:
+                print("Error: Bad request. Invalid parameters or missing map.")
+                return None
+            elif response.status_code == 401:
+                print("Error: Unauthorized. Invalid session key or map number.")
+                return None
+            else:
+                try:
+                    error_message = response.json().get('message', 'Unknown error')
+                except:
+                    error_message = f"HTTP {response.status_code}: {response.text}"
+                print(f"Embedding addplot failed. Server responded with error: {error_message}")
+                return None
+
+        except requests.exceptions.RequestException as e:
+            print(f"Network error during file upload: {str(e)}")
+            return None
+        except Exception as e:
+            print(f"Error processing embedding addplot: {str(e)}")
+            return None
+        finally:
+            # Ensure file handles are closed
+            for _, file_handle in files_to_upload:
+                try:
+                    file_handle.close()
+                except:
+                    pass
+            # Remove the temporary CSV file created from ndarray/DataFrame input
+            if temp_csv_path is not None:
+                try:
+                    os.remove(temp_csv_path)
+                except:
+                    pass
+
+    @pre_authentication
     def basemap_csvform(self, files, weight_option_str=None, type_option_str=None,
                     drop_columns=None, label=None, tag=None, description=None,
                     random_seed=42, identna_resolution=None, identna_effective_radius=None,
@@ -1122,6 +1292,151 @@ class toorPIA:
             for _, file_handle in files_to_upload:
                 try:
                     file_handle.close()
+                except:
+                    pass
+
+    @pre_authentication
+    def basemap_embedding(self, files, l2_normalization=None, id_columns=None,
+                    label=None, tag=None, description=None,
+                    identna_resolution=None, identna_effective_radius=None,
+                    identna_er_method=None, identna_knn_k=None):
+        """
+        Create base map from embedding vectors with unified return structure
+
+        Accepts CSV file path(s) or in-memory embedding data (2D numpy.ndarray
+        or pandas.DataFrame). Input rows are samples and columns are embedding
+        dimensions; header rows are auto-detected and leading non-numeric
+        columns are auto-detected as ID/label columns. An ndarray is uploaded
+        as a headerless CSV so that dimension names are auto-generated
+        consistently between basemap and addplot; a DataFrame keeps its header.
+
+        Note:
+            vector_normalization is not applicable to embedding maps (the
+            engine always uses the euclidean distance mode).
+
+        Args:
+            files (str, list, numpy.ndarray or pandas.DataFrame): CSV file path(s) or in-memory embedding data
+            l2_normalization (bool, optional): Enable/disable L2 normalization of each input vector. Default server-side is True. Pass False for embeddings whose norm carries information.
+            id_columns (int, optional): Number of leading ID/label columns. Usually unnecessary: leading non-numeric columns are auto-detected. Set only when the ID columns look numeric.
+            label (str, optional): Map label
+            tag (str, optional): Map tag
+            description (str, optional): Map description
+            identna_resolution (int, optional): Mesh resolution (default: 100)
+            identna_effective_radius (float or "auto", optional): Effective radius. "auto" for automatic determination (default: 0.1)
+            identna_er_method (str, optional): Bandwidth method when effective_radius="auto": "silverman" (default) or "knn"
+            identna_knn_k (int, optional): k for knn method (0 = auto ceil(sqrt(n)))
+
+        Returns:
+            dict: Dictionary containing:
+                - xyData: Coordinate data as NumPy array (each row is [x, y])
+                - mapNo: Map number
+                - shareUrl: Share URL for the map
+        """
+        # ndarray/DataFrame direct input: convert to a temporary CSV file
+        temp_csv_path = None
+        if not isinstance(files, (str, list)):
+            temp_csv_path = self._convert_inmemory_embedding(files)
+            if temp_csv_path is None:
+                return None
+            files = [temp_csv_path]
+
+        # File existence and format check (accept both string and list)
+        if isinstance(files, str):
+            files = [files]  # Convert single file to list
+
+        if not files or not isinstance(files, list):
+            print("Error: files must be a file path (string) or list of file paths")
+            return None
+
+        files_to_upload = []
+        for file_path in files:
+            if not os.path.exists(file_path):
+                print(f"Error: File not found: {file_path}")
+                return None
+
+            # File format check (.csv only)
+            ext = os.path.splitext(file_path)[1].lower()
+            if ext != '.csv':
+                print(f"Error: Unsupported file format: {ext}. Only .csv files are supported.")
+                return None
+
+            files_to_upload.append(('files', open(file_path, 'rb')))
+
+        try:
+            # Prepare form data
+            form_data = {
+                'label': label or '',
+                'tag': tag or '',
+                'description': description or ''
+            }
+
+            # 前処理オプション: 明示指定された場合のみ送信（サーバー側デフォルトに委ねる）
+            if l2_normalization is not None:
+                form_data['l2_normalization'] = 'true' if bool(l2_normalization) else 'false'
+            if id_columns is not None:
+                form_data['id_columns'] = str(int(id_columns))
+
+            # Add identna parameters
+            identna_params = {}
+            if identna_resolution is not None:
+                identna_params['resolution'] = int(identna_resolution)
+            if identna_effective_radius is not None:
+                identna_params['effectiveRadius'] = identna_effective_radius if identna_effective_radius == 'auto' else float(identna_effective_radius)
+            if identna_er_method is not None:
+                identna_params['erMethod'] = identna_er_method
+            if identna_knn_k is not None:
+                identna_params['knnK'] = int(identna_knn_k)
+            if identna_params:
+                form_data['identna_params'] = json.dumps(identna_params)
+
+            # Send as multipart/form-data to new basemap_embedding endpoint
+            headers = {'session-key': self.session_key}  # Content-Type is auto-set by requests
+            response = requests.post(
+                f"{API_URL}/data/basemap_embedding",
+                files=files_to_upload,
+                data=form_data,
+                headers=headers
+            )
+
+            if response.status_code == 200:
+                response_data = response.json()
+                baseXyData = response_data['resdata']['baseXyData']
+                self.mapNo = response_data['resdata']['mapNo']
+                self.shareUrl = response_data.get('shareUrl')  # Save share URL
+
+                np_array = np.array(baseXyData)  # Convert baseXyData to NumPy array
+
+                # Return unified structure similar to addplot methods
+                return {
+                    'xyData': np_array,
+                    'mapNo': self.mapNo,
+                    'shareUrl': self.shareUrl
+                }
+            else:
+                try:
+                    error_message = response.json().get('message', 'Unknown error')
+                except:
+                    error_message = f"HTTP {response.status_code}: {response.text}"
+                print(f"Embedding basemap creation failed. Server responded with error: {error_message}")
+                return None
+
+        except requests.exceptions.RequestException as e:
+            print(f"Network error during embedding CSV upload: {str(e)}")
+            return None
+        except Exception as e:
+            print(f"Error processing embedding basemap file: {str(e)}")
+            return None
+        finally:
+            # Ensure file handles are closed
+            for _, file_handle in files_to_upload:
+                try:
+                    file_handle.close()
+                except:
+                    pass
+            # Remove the temporary CSV file created from ndarray/DataFrame input
+            if temp_csv_path is not None:
+                try:
+                    os.remove(temp_csv_path)
                 except:
                     pass
 
@@ -1544,4 +1859,52 @@ class toorPIA:
         type_option_str = ",".join(type_options) if type_options else ""
         
         return weight_option_str, type_option_str
+
+    def _convert_inmemory_embedding(self, data):
+        """
+        Convert in-memory embedding data (2D numpy.ndarray or pandas.DataFrame)
+        into a temporary CSV file for multipart upload (embedding methods only).
+
+        An ndarray is written WITHOUT a header so that the server auto-generates
+        consistent dimension names, keeping base and add column names
+        aligned. A DataFrame is written WITH its header.
+
+        Args:
+            data (numpy.ndarray or pandas.DataFrame): Embedding data (rows=samples, columns=dimensions)
+
+        Returns:
+            str: Path of the temporary CSV file, or None on failure.
+                 The caller is responsible for removing the file.
+        """
+        temp_path = None
+        try:
+            import tempfile
+            import pandas as pd  # pandasはndarray/DataFrame入力時のみ必要
+
+            if isinstance(data, np.ndarray):
+                if data.ndim != 2:
+                    print("Error: ndarray input must be 2-dimensional (rows=samples, columns=dimensions)")
+                    return None
+                fd, temp_path = tempfile.mkstemp(suffix='.csv')
+                os.close(fd)
+                # headerless output: the server auto-generates the dimension names,
+                # which keeps headerless add data compatible with the basemap's column names
+                pd.DataFrame(data).to_csv(temp_path, index=False, header=False)
+                return temp_path
+            elif isinstance(data, pd.DataFrame):
+                fd, temp_path = tempfile.mkstemp(suffix='.csv')
+                os.close(fd)
+                data.to_csv(temp_path, index=False)  # DataFrame keeps its own header
+                return temp_path
+            else:
+                print("Error: files must be a file path (string), list of file paths, 2D numpy.ndarray, or pandas.DataFrame")
+                return None
+        except Exception as e:
+            print(f"Error converting in-memory embedding data to CSV: {str(e)}")
+            if temp_path is not None:
+                try:
+                    os.remove(temp_path)
+                except:
+                    pass
+            return None
 


### PR DESCRIPTION
## 概要

backend の新エンドポイント `/data/basemap_embedding` / `/data/addplot_embedding` に対応するクライアントメソッドを追加し、**v1.1.1 → v1.2.0** にバンプします。あわせて samples の既存バグを1件修正します。

## 追加メソッド

```python
# ベースマップ作成 — CSVパスまたは ndarray/DataFrame を直接入力可能
result = client.basemap_embedding(embeddings_ndarray)          # 2次元 ndarray
result = client.basemap_embedding("features.csv",
                                  l2_normalization=False,      # ノルムが情報を持つ埋め込み用
                                  id_columns=1)                # ID列が数値に見える場合のみ

# 追加プロット — 前処理オプションはサーバ側で basemap から自動継承
result = client.addplot_embedding(new_embeddings, mapNo=result["mapNo"])
```

- **未指定パラメータは送信しない**既存流儀を踏襲（サーバ既定に委ねる）
- `vector_normalization` は embedding では無効（エンジンが常にユークリッド距離モードを使用）のため**引数自体を設けない**
- `addplot_embedding` は前処理オプション（`l2_normalization` / `id_columns`）を受け付けない — サーバ側で basemap から自動継承され、basemap と addplot の前処理の同一性が保証されるため。mapNo のみ対応（map ディレクトリは既存の `import_map()` → mapNo フローを使用）
- ndarray は**ヘッダなし CSV**、DataFrame は**ヘッダ付き CSV** に変換して multipart 送信（ヘッダなしにすることでサーバが生成する列名が base/add 間で一致する）

## ドキュメント / サンプル

- `docs/api-reference.md`: 両メソッドのリファレンス、Process Method Compatibility マトリクスに embedding 行/列を追加（embedding ↔ `addplot_embedding` のみ互換）、前処理パラメータ詳細
- `README.md`: Embedding Data Analysis セクション（CSV / ndarray 両方の例）
- `samples/test_basemap_embedding.py`: 合成埋め込みによる basemap → addplot E2E サンプル

## fix: test_addplot_history.py（2つ目のコミット）

`client.addplot()` の戻り値が ndarray → dict に変わった際にサンプルが追従しておらず、`add_result.shape` の AttributeError で**どのサーバに対しても4章で必ず中断**していました。`add_result['xyData'].shape` に修正し、全8章の通し実行成功を確認済み。

## 検証

- 対応 backend の実機に対し、実データ（1961サンプル×768次元の画像特徴量）で `basemap_embedding`（L2 on/off 両条件）→ `addplot_embedding` の E2E を実施し、結果の正しさを確認済み
- 既存メソッドへの変更はゼロ（`client.py` の diff は完全に追加のみ）。v1.1.1 の samples 全件が対応サーバで従来どおり動作することも別途確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
