### PR TITLE
fix: addplot系の detabn threshold を未指定時は送信しない

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -532,7 +532,7 @@ result = client.addplot(
     df_add,
     detabn_max_window=3,        # Maximum window size (default: 5)
     detabn_rate_threshold=0.5,  # Abnormality rate threshold (default: 1.0)
-    detabn_threshold=0.1,       # Normal area threshold (default: 0)
+    detabn_threshold=0.1,       # Normal area threshold (default: omitted → auto-derived by the server)
     detabn_print_score=True     # Print score information (default: True)
 )
 
@@ -550,7 +550,7 @@ print(f"XY Data: {result['xyData'].shape}")                  # NumPy array of co
 **detabn Parameters:**
 - `detabn_max_window`: Maximum number of sequential data points used for abnormality rate calculation
 - `detabn_rate_threshold`: Lower threshold for abnormality rate (0.0 < rate <= 1.0). If rate >= threshold, data is considered abnormal
-- `detabn_threshold`: Threshold for relative normal area value. If value > threshold, the point is considered normal
+- `detabn_threshold`: Threshold for relative normal area value. If value > threshold, the point is considered normal. When omitted, the server auto-derives the threshold so that the normal area covers ~90% of the basemap (detabn's coverage default), which is recommended
 - `detabn_print_score`: Whether to include detailed score information in the analysis
 
 **Return Value Enhancement:**
@@ -869,7 +869,7 @@ Abnormality detection parameters:
 
 - **detabn_max_window** (int, default=5): Maximum number of sequential data points used for abnormality rate calculation
 - **detabn_rate_threshold** (float, default=1.0): Lower threshold for abnormality rate (0.0 < rate <= 1.0). If rate >= threshold, data is considered abnormal
-- **detabn_threshold** (int/float, default=0): Threshold for relative normal area value. If value > threshold, the point is considered normal
+- **detabn_threshold** (float, optional): Threshold for relative normal area value. If value > threshold, the point is considered normal. When omitted (recommended), the server auto-derives the threshold from detabn's coverage default (0.90) so the normal area covers ~90% of the basemap. Note: passing an explicit value (including 0) disables this auto-derivation
 - **detabn_print_score** (bool, default=True): Whether to include detailed score information in the analysis
 
 ### Embedding Preprocessing Parameters

--- a/toorpia/client.py
+++ b/toorpia/client.py
@@ -478,7 +478,7 @@ class toorPIA:
                         identna_er_method=None, identna_knn_k=None,
                         # detabn parameters
                         detabn_max_window=5, detabn_rate_threshold=1.0,
-                        detabn_threshold=0, detabn_print_score=True,
+                        detabn_threshold=None, detabn_print_score=True,
                         # Legacy mkfftSeg parameters (deprecated - for backward compatibility warnings)
                         mkfftseg_di=None, mkfftseg_hp=None, mkfftseg_lp=None, 
                         mkfftseg_nm=None, mkfftseg_ol=None, mkfftseg_sr=None,
@@ -499,7 +499,7 @@ class toorPIA:
             identna_knn_k (int, optional): k for knn method (0 = auto ceil(sqrt(n)))
             detabn_max_window (int): Maximum window size for abnormality detection
             detabn_rate_threshold (float): Rate threshold for abnormality detection
-            detabn_threshold (int): Threshold value for abnormality detection
+            detabn_threshold (float, optional): Threshold for relative normal area value. When omitted (None), the server auto-derives it from detabn's coverage default (0.90)
             detabn_print_score (bool): Whether to print abnormality score
 
         Returns:
@@ -571,12 +571,15 @@ class toorPIA:
                 identna_params['knnK'] = int(identna_knn_k)
             
             # Prepare detabn parameters
+            # threshold は明示指定時のみ送信する。省略時はサーバ側で detabn の
+            # -coverage デフォルト(0.90)から自動導出される（0 を送るとそれが無効になる）
             detabn_params = {
                 'maxWindow': int(detabn_max_window),
                 'rateThreshold': float(detabn_rate_threshold),
-                'threshold': int(detabn_threshold),
                 'printScore': bool(detabn_print_score)
             }
+            if detabn_threshold is not None:
+                detabn_params['threshold'] = float(detabn_threshold)
             
             # Send as form-data
             form_data = {
@@ -849,7 +852,7 @@ class toorPIA:
                        identna_er_method=None, identna_knn_k=None,
                        # detabn parameters
                        detabn_max_window=5, detabn_rate_threshold=1.0,
-                       detabn_threshold=0, detabn_print_score=True):
+                       detabn_threshold=None, detabn_print_score=True):
         """
         Process CSV files for addplot (additional plot) analysis
         Uses the same CSV processing options as the base map (stored in database)
@@ -863,7 +866,7 @@ class toorPIA:
             identna_knn_k (int, optional): k for knn method (0 = auto ceil(sqrt(n)))
             detabn_max_window (int): Maximum window size for abnormality detection
             detabn_rate_threshold (float): Rate threshold for abnormality detection
-            detabn_threshold (int): Threshold value for abnormality detection
+            detabn_threshold (float, optional): Threshold for relative normal area value. When omitted (None), the server auto-derives it from detabn's coverage default (0.90)
             detabn_print_score (bool): Whether to print abnormality score
 
         Returns:
@@ -919,12 +922,15 @@ class toorPIA:
                 identna_params['knnK'] = int(identna_knn_k)
             
             # Prepare detabn parameters
+            # threshold は明示指定時のみ送信する。省略時はサーバ側で detabn の
+            # -coverage デフォルト(0.90)から自動導出される（0 を送るとそれが無効になる）
             detabn_params = {
                 'maxWindow': int(detabn_max_window),
                 'rateThreshold': float(detabn_rate_threshold),
-                'threshold': int(detabn_threshold),
                 'printScore': bool(detabn_print_score)
             }
+            if detabn_threshold is not None:
+                detabn_params['threshold'] = float(detabn_threshold)
             
             # Send as form-data
             form_data = {
@@ -997,7 +1003,7 @@ class toorPIA:
                          identna_er_method=None, identna_knn_k=None,
                          # detabn parameters
                          detabn_max_window=5, detabn_rate_threshold=1.0,
-                         detabn_threshold=0, detabn_print_score=True):
+                         detabn_threshold=None, detabn_print_score=True):
         """
         Process embedding data for addplot (additional plot) analysis
 
@@ -1020,7 +1026,7 @@ class toorPIA:
             identna_knn_k (int, optional): k for knn method (0 = auto ceil(sqrt(n)))
             detabn_max_window (int): Maximum window size for abnormality detection
             detabn_rate_threshold (float): Rate threshold for abnormality detection
-            detabn_threshold (int): Threshold value for abnormality detection
+            detabn_threshold (float, optional): Threshold for relative normal area value. When omitted (None), the server auto-derives it from detabn's coverage default (0.90)
             detabn_print_score (bool): Whether to print abnormality score
 
         Returns:
@@ -1082,12 +1088,15 @@ class toorPIA:
                 identna_params['knnK'] = int(identna_knn_k)
 
             # Prepare detabn parameters
+            # threshold は明示指定時のみ送信する。省略時はサーバ側で detabn の
+            # -coverage デフォルト(0.90)から自動導出される（0 を送るとそれが無効になる）
             detabn_params = {
                 'maxWindow': int(detabn_max_window),
                 'rateThreshold': float(detabn_rate_threshold),
-                'threshold': int(detabn_threshold),
                 'printScore': bool(detabn_print_score)
             }
+            if detabn_threshold is not None:
+                detabn_params['threshold'] = float(detabn_threshold)
 
             # Send as form-data
             form_data = {


### PR DESCRIPTION
## 概要

`addplot_csvform` / `addplot_waveform` / `addplot_embedding` は `detabn_threshold` のデフォルト値 `0` を常に `detabn_options` に含めて送信していました。backend は threshold **省略時**に detabn の `-coverage` デフォルト(0.90)から閾値を自動導出する仕様（`services/dataService.js`）のため、`0` の明示送信はこの自動導出を無効化し、異常検出感度を下げていました。

## 変更点

- `detabn_threshold` のデフォルトを `0` → `None` に変更し、**明示指定時のみ送信**（3メソッド）
- `int(detabn_threshold)` の切り捨てを `float()` に修正 — ドキュメントの例どおり `0.1` を指定しても `0` として送信されていたバグの解消
- `addplot()`（JSON系）は元々指定時のみ送信のため変更なし
- `docs/api-reference.md` の「default: 0」記述（3箇所）を自動導出仕様の説明に更新

## 検証

- モック検証: 3メソッドすべてで「省略時は `threshold` キー非送信」「`0.1` 指定時は float のまま送信」を確認
- 本番API実測: embedding マップ (map 1823) に正常5点＋異常3点の同一データを addplot し、修正前は `normal` と誤判定 → 修正後は `abnormal` (composite: warning, score 0.55) と正しく判定されることを確認

## 互換性への影響

detabn パラメータ未指定の既存コードは、今後 coverage ベースの自動導出閾値によるより感度の高い（正しい）判定になります。次回リリースのリリースノートに記載推奨です。

関連: toorpia/backend#113（ドキュメント上の default: 0 と実挙動の不一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)