### PR TITLE
feat: 非同期ジョブモード対応 — 全basemap/addplot系メソッドに async_mode 引数を追加 (v1.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,46 @@ print(f"Anomaly status: {addplot_result['abnormalityStatus']}")
 - `basemap_*()`: Returns `dict` with structured metadata (`xyData`, `mapNo`, `shareUrl`)
 - **Both approaches**: Automatically update `client.mapNo` and `client.shareUrl` attributes
 
+### Asynchronous Job Mode (`async_mode=True`)
+
+For large datasets (tens of thousands of records), engine processing can take several
+minutes, and a synchronous request may be cut off by proxy/load-balancer idle timeouts
+before the result arrives. All basemap/addplot methods (`fit_transform()`, `addplot()`,
+`basemap_csvform()`, `basemap_waveform()`, `basemap_embedding()`, `addplot_csvform()`,
+`addplot_waveform()`, `addplot_embedding()`) accept `async_mode=True`, which submits the
+request in the server's asynchronous job mode and returns a `Job` handle immediately:
+
+```python
+# Submit and wait for completion (recommended for long-running jobs)
+job = client.basemap_csvform(["large_data.csv"], async_mode=True)
+result = job.wait()                      # Polls every 5s; same return value as the sync call
+print(result['mapNo'], result['shareUrl'])
+
+# Non-blocking polling
+import time
+job = client.addplot_csvform(["new_data.csv"], async_mode=True)
+while not job.finished:
+    print(f"status: {job.status}")       # 'queued' -> 'running' -> 'done' | 'failed'
+    time.sleep(10)
+    job.refresh()
+result = job.result()                    # Same return value as the sync call
+
+# Custom polling interval / timeout (job keeps running server-side after a timeout)
+result = job.wait(poll_interval=10, timeout=1800)
+
+# Raw job status (also usable to re-fetch results later; kept for 24h after completion)
+info = client.get_job(job.job_id)        # {'jobId': ..., 'status': ..., 'result': ..., ...}
+```
+
+Notes:
+- `job.wait()` / `job.result()` return exactly what the synchronous call would have
+  returned, and update `client.mapNo` / `client.currentAddPlotNo` / `client.shareUrl`
+  the same way.
+- Results are kept for 24 hours after completion (server setting); up to 5 jobs per
+  user can be queued/running at once (submissions beyond that fail with an error).
+- On servers without async support, the request falls back to synchronous execution
+  and the same method returns the synchronous result directly.
+
 ---
 
 ## Documentation

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -15,6 +15,7 @@ This document provides detailed specifications for all methods and parameters of
 - [Alternative Methods](#alternative-methods)
   - [fit_transform()](#fit_transform) - DataFrame-based processing
   - [addplot()](#addplot) - DataFrame-based anomaly detection
+- [Asynchronous Job Mode](#asynchronous-job-mode) - `async_mode=True` for long-running jobs
 - [Map Management](#map-management)
 - [Parameter Details](#parameter-details)
 - [Return Values](#return-values)
@@ -720,6 +721,61 @@ print(f"Share URL: {result['shareUrl']}")
 - **No Column Specification Needed**: Unlike general addplot methods, you don't need to specify weight or type options—they're automatically retrieved from the database
 - **Dimension Validation**: The system automatically validates that the uploaded CSV has the same effective number of columns as the base map
 - **Process Method Compatibility**: Only works with maps created using `fit_transform_csvform` (CSV-based maps)
+
+---
+
+## Asynchronous Job Mode
+
+All basemap/addplot methods (`basemap_csvform()`, `basemap_waveform()`, `basemap_embedding()`,
+`addplot_csvform()`, `addplot_waveform()`, `addplot_embedding()`, `fit_transform()`, `addplot()`)
+accept an `async_mode` keyword argument. With `async_mode=True`, the request is submitted in the
+server's asynchronous job mode (`?async=true`): the server responds immediately with a job ID and
+the method returns a `toorpia.job.Job` handle instead of blocking until the engine finishes.
+
+This is recommended for large datasets where engine processing takes several minutes, because a
+long-running synchronous request can be cut off by proxy/load-balancer idle timeouts before the
+result (mapNo, addPlotNo, anomaly status) reaches the client.
+
+```python
+job = client.basemap_csvform(["large_data.csv"], async_mode=True)
+
+job.job_id     # e.g. "job_0123456789abcdef..."
+job.status     # 'queued' -> 'running' -> 'done' | 'failed'
+job.finished   # True when status is 'done' or 'failed'
+
+result = job.wait()   # Poll until completion; returns the same value as the synchronous call
+```
+
+### Job Methods
+
+| Method | Description |
+|--------|-------------|
+| `job.wait(poll_interval=5, timeout=None)` | Poll until completion and return the same value as the synchronous call. Returns `None` on timeout or job failure (the job keeps running server-side after a client timeout). |
+| `job.refresh()` | Poll once and update `job.status` / `job.raw`. Returns the current status string, or `None` if the poll failed. |
+| `job.result()` | Return the parsed result of a finished job (same value as the synchronous call). Client attributes (`mapNo`, `currentAddPlotNo`, `shareUrl`) are updated at this point, exactly as in synchronous execution. |
+
+### get_job()
+
+Fetches the raw job status from the server. Useful to re-fetch a result later (results are kept
+for 24 hours after completion, server-configurable) or to inspect timing metadata.
+
+```python
+info = client.get_job("job_0123456789abcdef...")
+# {'jobId': ..., 'type': 'basemap_csvform', 'status': 'done', 'httpStatus': 200,
+#  'result': {...},  # same shape as the synchronous response body
+#  'createdAt': ..., 'startedAt': ..., 'finishedAt': ..., 'expiresAt': ...}
+```
+
+### Behavior Notes
+
+- Authentication errors (401), rate limits (429, including the per-user active job limit of 5),
+  and upload size errors (413/415) are still returned synchronously at submission time; in those
+  cases the method prints the error and returns `None`.
+- Business validation errors (e.g. invalid mapNo) are detected during job execution and surface
+  as a `failed` job; `job.wait()` prints the same error message as the synchronous call and
+  returns `None`.
+- On servers without async support, `?async=true` is ignored and the request runs synchronously;
+  the method then returns the synchronous result directly (with a note printed).
 
 ---
 

--- a/docs/release-notes/v1.3.0_jp.md
+++ b/docs/release-notes/v1.3.0_jp.md
@@ -1,0 +1,33 @@
+# toorPIA Python Client v1.3.0 リリースノート
+
+**リリース日:** 2026-07-24
+
+## 主な変更 (v1.2.0 以降)
+
+### 新機能 (feat)
+
+- **非同期ジョブモードに対応: 全 basemap/addplot 系メソッドに `async_mode` 引数を追加**
+  - 対象メソッド: `fit_transform()`, `addplot()`, `basemap_csvform()`, `basemap_waveform()`, `basemap_embedding()`, `addplot_csvform()`, `addplot_waveform()`, `addplot_embedding()`
+  - `async_mode=True` を指定すると、backend の非同期ジョブモード（`?async=true`）でリクエストを投入し、エンジン処理の完了を待たずに **`Job` ハンドル**（`toorpia.job.Job`）を即座に返します。数万点規模のデータでエンジン処理が数分かかる場合でも、経路上のプロキシ / ロードバランサのアイドルタイムアウトによる切断で結果（mapNo・addPlotNo・異常判定）を取りこぼす心配がなくなります。
+  - `job.wait(poll_interval=5, timeout=None)` で完了までポーリングでき、**同期実行時とまったく同じ形の返り値**が得られます。`client.mapNo` / `client.currentAddPlotNo` / `client.shareUrl` の属性更新も同期実行時と同様に行われます。
+  - ノンブロッキングに扱う場合は `job.refresh()` / `job.status` / `job.finished` / `job.result()` を利用できます。
+  - `client.get_job(job_id)` で生のジョブ情報（`status`, `httpStatus`, `result` / `error`, 各種タイムスタンプ）を取得できます。ジョブ結果はサーバ側で完了後24時間（サーバ設定による）保持されるため、後からの再取得も可能です。
+  - 投入時に同期で返るエラー（認証 401・同時アクティブジョブ数超過 429・アップロードサイズ超過 413/415）は従来同様エラーメッセージを表示して `None` を返します。ジョブ実行中のエラー（mapNo 不正等）は `failed` ジョブとして `job.wait()` が同期実行時と同じエラーメッセージを表示し `None` を返します。
+  - **旧サーバーへのフォールバック**: 非同期モード未対応の backend は `?async=true` を無視して同期実行するため、その場合は同期実行の結果をそのまま返します（注記メッセージを表示）。
+  - 利用には非同期ジョブモード（`?async=true` と `GET /jobs/:jobId`）対応版の toorPIA backend が必要です。
+
+### 内部変更 (refactor)
+
+- 各メソッドのレスポンス処理を同期・非同期で共通のハンドラ（`_handle_fit_transform_response` / `_handle_basemap_response` / `_handle_addplot_response` / `_handle_addplot_file_response`）に集約しました。非同期ジョブの `result` / `error` は同期実行時のレスポンスボディと同形のため、同一コードパスで処理されます。
+- `pre_authentication` デコレータに `functools.wraps` を適用し、`help()` や IDE でメソッドの本来のシグネチャ・docstring が参照できるようになりました。
+
+### ドキュメント / テスト
+
+- `README.md`: Advanced Features に「Asynchronous Job Mode」セクションを追加
+- `docs/api-reference.md`: 「Asynchronous Job Mode」セクション（Job メソッド一覧・`get_job()`・挙動の注意点）を追加
+- `test/test_client.py`: `test_fit_transform_async` / `test_addplot_async` を追加（実サーバに対する E2E 確認済み）
+
+## 後方互換性
+
+- `async_mode` の既定値は `False` であり、未指定時のリクエスト・挙動は従来と完全に同一です。v1.2.0 からの移行に伴うユーザコードの修正は不要です。
+- 廃止予定の `fit_transform_waveform()` / `fit_transform_csvform()` には `async_mode` を追加していません。非同期モードが必要な場合は後継の `basemap_waveform()` / `basemap_csvform()` を使用してください。

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='toorpia',
-    version='1.2.0',
+    version='1.3.0',
     author='toor Inc.',
     author_email='takaeda@toor.jpn.com',
     description='API Frontend libraries of toorpia',

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -6,6 +6,7 @@ import subprocess
 import random
 import string
 from toorpia.client import toorPIA
+from toorpia.job import Job
 
 def test_fit_transform():
     # APIキーを環境変数から取得するか、ダミーの値を使用
@@ -39,6 +40,50 @@ def test_addplot():
 
     # 結果の検証
     assert add_result is not None
+
+def test_fit_transform_async():
+    api_key = os.environ.get("TOORPIA_API_KEY", "dummy_api_key")
+    toorpia_client = toorPIA(api_key=api_key)
+
+    # テストデータを読み込む
+    df = pd.read_csv("./test/rawdata/biopsy.csv")
+    df = df.drop(columns=["No", "ID", "Diagnosis"])
+
+    # async_mode=True で投入すると Job ハンドルが即座に返る
+    job = toorpia_client.fit_transform(df, async_mode=True)
+    assert isinstance(job, Job)
+    assert job.job_id is not None
+
+    # get_jobで生のジョブ情報を取得できる
+    info = toorpia_client.get_job(job.job_id)
+    assert info is not None
+    assert info["status"] in ("queued", "running", "done", "failed")
+
+    # 完了までポーリングすると同期実行時と同じ返り値が得られる
+    result = job.wait(poll_interval=2, timeout=600)
+    assert result is not None
+    assert job.status == "done"
+    assert toorpia_client.mapNo is not None
+
+def test_addplot_async():
+    api_key = os.environ.get("TOORPIA_API_KEY", "dummy_api_key")
+    toorpia_client = toorPIA(api_key=api_key)
+
+    # テストデータを読み込む
+    df = pd.read_csv("./test/rawdata/biopsy.csv")
+    df = df.drop(columns=["No", "ID", "Diagnosis"])
+
+    # まずfit_transformを呼び出してマップを作成
+    toorpia_client.fit_transform(df)
+
+    # addplotを非同期モードで実行する
+    job = toorpia_client.addplot(df, async_mode=True)
+    assert isinstance(job, Job)
+
+    add_result = job.wait(poll_interval=2, timeout=600)
+    assert add_result is not None
+    assert add_result["xyData"] is not None
+    assert toorpia_client.currentAddPlotNo is not None
 
 def test_list_map():
     api_key = os.environ.get("TOORPIA_API_KEY", "dummy_api_key")

--- a/toorpia/__init__.py
+++ b/toorpia/__init__.py
@@ -1,1 +1,2 @@
 from .client import toorPIA
+from .job import Job

--- a/toorpia/client.py
+++ b/toorpia/client.py
@@ -2,7 +2,9 @@ import requests
 import json
 import os
 import base64
+import functools
 from .config import API_URL
+from .job import Job
 from .utils.authentication import get_api_key
 import numpy as np
 import hashlib
@@ -10,6 +12,7 @@ import glob
 
 # デコレータを定義
 def pre_authentication(method):
+    @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
         if not self.session_key:
             self.session_key = self.authenticate()
@@ -40,8 +43,69 @@ class toorPIA:
             print(f"Response content: {response.text}")
             return None
 
+    @staticmethod
+    def _async_params(async_mode):
+        """async_mode=True のとき非同期ジョブモード指定のクエリパラメータを返す"""
+        return {'async': 'true'} if async_mode else None
+
+    def _handle_job_submission(self, response, parser):
+        """?async=true 投入レスポンスを処理し、Job ハンドルを返す
+
+        認証エラー(401)・アクティブジョブ数超過(429)・アップロードサイズ超過(413/415)
+        などは投入時に同期で返るため、ここでエラー表示して None を返す。
+        非同期モード未対応の旧サーバーは ?async=true を無視して同期実行の 200 を
+        返すため、その場合は同期実行時と同じ返り値をそのまま返す。
+        """
+        if response.status_code == 202:
+            body = response.json()
+            return Job(self, body['jobId'], parser)
+        if response.status_code == 200:
+            print("Note: server does not support asynchronous job mode; the request was executed synchronously.")
+            return parser(response)
+        try:
+            error_message = response.json().get('message', 'Unknown error')
+        except:
+            error_message = f"HTTP {response.status_code}: {response.text}"
+        print(f"Job submission failed. Server responded with error: {error_message}")
+        return None
+
     @pre_authentication
-    def fit_transform(self, data, label=None, tag=None, description=None, random_seed=42, weight_option_str=None, type_option_str=None, identna_resolution=None, identna_effective_radius=None, identna_er_method=None, identna_knn_k=None, vector_normalization=None):
+    def get_job(self, job_id):
+        """非同期ジョブ (async_mode=True) の現在の状態を取得する
+
+        Args:
+            job_id (str): ジョブ投入時に返された jobId
+
+        Returns:
+            dict: ジョブ情報 (jobId, type, status, createdAt, startedAt, finishedAt,
+                  expiresAt。status が done のとき httpStatus と result、failed のとき
+                  httpStatus と error を含む。result / error は同期実行時のレスポンス
+                  ボディと同形)。取得に失敗した場合は None。
+                  結果は完了後24時間（サーバー設定による）保持され、期限後は404となる
+        """
+        headers = {'Content-Type': 'application/json', 'session-key': self.session_key}
+        try:
+            response = requests.get(f"{API_URL}/jobs/{job_id}", headers=headers)
+            if response.status_code == 401:
+                # 長時間ジョブのポーリング中にセッションが切れることがあるため一度だけ再認証する
+                self.session_key = self.authenticate()
+                if self.session_key:
+                    headers['session-key'] = self.session_key
+                    response = requests.get(f"{API_URL}/jobs/{job_id}", headers=headers)
+        except requests.exceptions.RequestException as e:
+            print(f"Network error while polling job {job_id}: {str(e)}")
+            return None
+        if response.status_code == 200:
+            return response.json()
+        try:
+            error_message = response.json().get('message', 'Unknown error')
+        except:
+            error_message = f"HTTP {response.status_code}"
+        print(f"Failed to get job {job_id}. Server responded with error: {error_message}")
+        return None
+
+    @pre_authentication
+    def fit_transform(self, data, label=None, tag=None, description=None, random_seed=42, weight_option_str=None, type_option_str=None, identna_resolution=None, identna_effective_radius=None, identna_er_method=None, identna_knn_k=None, vector_normalization=None, async_mode=False):
         headers = {'Content-Type': 'application/json', 'session-key': self.session_key}
 
         # DataFrameの型に基づいて自動生成（パラメータが指定されていない場合）
@@ -80,7 +144,14 @@ class toorPIA:
         if vector_normalization is not None:
             data_dict['vector_normalization'] = bool(vector_normalization)
 
-        response = requests.post(f"{API_URL}/data/fit_transform", json=data_dict, headers=headers)
+        response = requests.post(f"{API_URL}/data/fit_transform", json=data_dict, headers=headers,
+                                 params=self._async_params(async_mode))
+        if async_mode:
+            return self._handle_job_submission(response, self._handle_fit_transform_response)
+        return self._handle_fit_transform_response(response)
+
+    def _handle_fit_transform_response(self, response):
+        """fit_transform のレスポンス処理（同期・非同期ジョブ結果の共通処理）"""
         if response.status_code == 200:
             response_data = response.json()
             baseXyData = response_data['resdata']['baseXyData']
@@ -376,7 +447,7 @@ class toorPIA:
                     pass
 
     @pre_authentication
-    def addplot(self, data, *args, weight_option_str=None, type_option_str=None, identna_resolution=None, identna_effective_radius=None, identna_er_method=None, identna_knn_k=None, detabn_max_window=None, detabn_rate_threshold=None, detabn_threshold=None, detabn_print_score=None):
+    def addplot(self, data, *args, weight_option_str=None, type_option_str=None, identna_resolution=None, identna_effective_radius=None, identna_er_method=None, identna_knn_k=None, detabn_max_window=None, detabn_rate_threshold=None, detabn_threshold=None, detabn_print_score=None, async_mode=False):
         headers = {'Content-Type': 'application/json', 'session-key': self.session_key}
 
         # DataFrameの型に基づいて自動生成（パラメータが指定されていない場合）
@@ -439,27 +510,16 @@ class toorPIA:
             print("Error: Both mapNo and mapDataDir are undefined.")
             return None
 
-        response = requests.post(f"{API_URL}/data/addplot", json=data_dict, headers=headers)
-        if response.status_code == 200:
-            response_data = response.json()
-            addXyData = response_data['resdata']
-            self.currentAddPlotNo = response_data.get('addPlotNo')  # 追加プロット番号を保存
-            self.shareUrl = response_data.get('shareUrl')  # シェアURLを保存
-            
-            # 座標データをNumPy配列に変換
-            np_array = np.array(addXyData)
-            
-            # 拡張された返り値：座標データと異常度情報を含む辞書を返す
-            result = {
-                'xyData': np_array,
-                'addPlotNo': self.currentAddPlotNo,
-                'abnormalityStatus': response_data.get('abnormalityStatus'),  # 'normal', 'abnormal', 'unknown'
-                'abnormalityScore': response_data.get('abnormalityScore'),    # 異常度スコア
-                'diagnosticScore': response_data.get('diagnosticScore'),     # 複合診断スコア
-                'shareUrl': self.shareUrl
-            }
+        response = requests.post(f"{API_URL}/data/addplot", json=data_dict, headers=headers,
+                                 params=self._async_params(async_mode))
+        if async_mode:
+            return self._handle_job_submission(response, self._handle_addplot_response)
+        return self._handle_addplot_response(response)
 
-            return result
+    def _handle_addplot_response(self, response):
+        """addplot のレスポンス処理（同期・非同期ジョブ結果の共通処理）"""
+        if response.status_code == 200:
+            return self._build_addplot_result(response.json())
         elif response.status_code == 400:
             print("Error: Bad request. Both mapNo and mapData are missing.")
             return None
@@ -471,6 +531,61 @@ class toorPIA:
             print(f"Data addition failed. Server responded with error: {error_message}")
             return None
 
+    def _build_addplot_result(self, response_data):
+        """addplot系レスポンスボディから返り値の辞書を組み立て、クライアント属性を更新する"""
+        addXyData = response_data['resdata']
+        self.currentAddPlotNo = response_data.get('addPlotNo')  # 追加プロット番号を保存
+        self.shareUrl = response_data.get('shareUrl')  # シェアURLを保存
+
+        # 座標データをNumPy配列に変換
+        np_array = np.array(addXyData)
+
+        # 拡張された返り値：座標データと異常度情報を含む辞書を返す
+        return {
+            'xyData': np_array,
+            'addPlotNo': self.currentAddPlotNo,
+            'abnormalityStatus': response_data.get('abnormalityStatus'),  # 'normal', 'abnormal', 'unknown'
+            'abnormalityScore': response_data.get('abnormalityScore'),    # 異常度スコア
+            'diagnosticScore': response_data.get('diagnosticScore'),     # 複合診断スコア
+            'shareUrl': self.shareUrl
+        }
+
+    def _handle_addplot_file_response(self, response, kind):
+        """addplot_waveform / addplot_csvform / addplot_embedding のレスポンス処理
+        （同期・非同期ジョブ結果の共通処理）
+
+        Args:
+            kind (str): 'waveform', 'csvform', 'embedding' のいずれか
+        """
+        error_labels = {'waveform': 'Waveform addplot', 'csvform': 'CSV addplot', 'embedding': 'Embedding addplot'}
+        if response.status_code == 200:
+            return self._build_addplot_result(response.json())
+        elif response.status_code == 400:
+            if kind == 'waveform':
+                try:
+                    error_response = response.json()
+                    error_code = error_response.get('error', '')
+                    if error_code == 'MKFFTSEG_OPTIONS_NOT_ALLOWED':
+                        print("Error: mkfftSeg options are not allowed in addplot_waveform.")
+                        print("The system automatically uses the basemap's mkfftSeg options for data consistency.")
+                    else:
+                        print("Error: Bad request. Invalid parameters or missing map.")
+                except:
+                    print("Error: Bad request. Invalid parameters or missing map.")
+            else:
+                print("Error: Bad request. Invalid parameters or missing map.")
+            return None
+        elif response.status_code == 401:
+            print("Error: Unauthorized. Invalid session key or map number.")
+            return None
+        else:
+            try:
+                error_message = response.json().get('message', 'Unknown error')
+            except:
+                error_message = f"HTTP {response.status_code}: {response.text}"
+            print(f"{error_labels[kind]} failed. Server responded with error: {error_message}")
+            return None
+
     @pre_authentication
     def addplot_waveform(self, files, mapNo=None,
                         # identna parameters
@@ -479,8 +594,10 @@ class toorPIA:
                         # detabn parameters
                         detabn_max_window=5, detabn_rate_threshold=1.0,
                         detabn_threshold=None, detabn_print_score=True,
+                        # async job mode
+                        async_mode=False,
                         # Legacy mkfftSeg parameters (deprecated - for backward compatibility warnings)
-                        mkfftseg_di=None, mkfftseg_hp=None, mkfftseg_lp=None, 
+                        mkfftseg_di=None, mkfftseg_hp=None, mkfftseg_lp=None,
                         mkfftseg_nm=None, mkfftseg_ol=None, mkfftseg_sr=None,
                         mkfftseg_wf=None, mkfftseg_wl=None):
         """
@@ -501,6 +618,9 @@ class toorPIA:
             detabn_rate_threshold (float): Rate threshold for abnormality detection
             detabn_threshold (float, optional): Threshold for relative normal area value. When omitted (None), the server auto-derives it from detabn's coverage default (0.90)
             detabn_print_score (bool): Whether to print abnormality score
+            async_mode (bool, optional): If True, submit in the server's asynchronous job
+                mode (?async=true) and return a Job handle immediately instead of blocking.
+                Call job.wait() to get the same return value as the synchronous call. Default: False.
 
         Returns:
             dict: Dictionary containing:
@@ -513,6 +633,7 @@ class toorPIA:
                     - distance: Distance analysis (meanDistance, distanceStd, radiusOfGyration, normalizedDistance, exceedanceRatio, threshold, status)
                     - compositeStatus: Combined status ('normal', 'warning', 'danger')
                 - shareUrl: Share URL for the map with this addplot
+            When async_mode=True, a toorpia.job.Job handle is returned instead.
 
         Note:
             mkfftSeg options (filters, window settings, etc.) are automatically inherited
@@ -591,55 +712,18 @@ class toorPIA:
             
             headers = {'session-key': self.session_key}  # Content-Type is auto-set by requests
             response = requests.post(
-                f"{API_URL}/data/addplot_waveform", 
+                f"{API_URL}/data/addplot_waveform",
                 files=files_to_upload,
                 data=form_data,
-                headers=headers
+                headers=headers,
+                params=self._async_params(async_mode)
             )
-            
-            if response.status_code == 200:
-                response_data = response.json()
-                addXyData = response_data['resdata']
-                self.currentAddPlotNo = response_data.get('addPlotNo')  # Save addplot number
-                self.shareUrl = response_data.get('shareUrl')  # Save share URL
-                
-                # Convert coordinate data to NumPy array
-                np_array = np.array(addXyData)
-                
-                # Return extended result with coordinate data and abnormality information
-                result = {
-                    'xyData': np_array,
-                    'addPlotNo': self.currentAddPlotNo,
-                    'abnormalityStatus': response_data.get('abnormalityStatus'),  # 'normal', 'abnormal', 'unknown'
-                    'abnormalityScore': response_data.get('abnormalityScore'),    # Abnormality score
-                    'diagnosticScore': response_data.get('diagnosticScore'),     # Composite diagnostic score
-                    'shareUrl': self.shareUrl
-                }
 
-                return result
-            elif response.status_code == 400:
-                try:
-                    error_response = response.json()
-                    error_code = error_response.get('error', '')
-                    if error_code == 'MKFFTSEG_OPTIONS_NOT_ALLOWED':
-                        print("Error: mkfftSeg options are not allowed in addplot_waveform.")
-                        print("The system automatically uses the basemap's mkfftSeg options for data consistency.")
-                    else:
-                        print("Error: Bad request. Invalid parameters or missing map.")
-                except:
-                    print("Error: Bad request. Invalid parameters or missing map.")
-                return None
-            elif response.status_code == 401:
-                print("Error: Unauthorized. Invalid session key or map number.")
-                return None
-            else:
-                try:
-                    error_message = response.json().get('message', 'Unknown error')
-                except:
-                    error_message = f"HTTP {response.status_code}: {response.text}"
-                print(f"Waveform addplot failed. Server responded with error: {error_message}")
-                return None
-                
+            if async_mode:
+                return self._handle_job_submission(
+                    response, lambda r: self._handle_addplot_file_response(r, 'waveform'))
+            return self._handle_addplot_file_response(response, 'waveform')
+
         except requests.exceptions.RequestException as e:
             print(f"Network error during file upload: {str(e)}")
             return None
@@ -852,7 +936,9 @@ class toorPIA:
                        identna_er_method=None, identna_knn_k=None,
                        # detabn parameters
                        detabn_max_window=5, detabn_rate_threshold=1.0,
-                       detabn_threshold=None, detabn_print_score=True):
+                       detabn_threshold=None, detabn_print_score=True,
+                       # async job mode
+                       async_mode=False):
         """
         Process CSV files for addplot (additional plot) analysis
         Uses the same CSV processing options as the base map (stored in database)
@@ -868,6 +954,9 @@ class toorPIA:
             detabn_rate_threshold (float): Rate threshold for abnormality detection
             detabn_threshold (float, optional): Threshold for relative normal area value. When omitted (None), the server auto-derives it from detabn's coverage default (0.90)
             detabn_print_score (bool): Whether to print abnormality score
+            async_mode (bool, optional): If True, submit in the server's asynchronous job
+                mode (?async=true) and return a Job handle immediately instead of blocking.
+                Call job.wait() to get the same return value as the synchronous call. Default: False.
 
         Returns:
             dict: Dictionary containing:
@@ -880,13 +969,14 @@ class toorPIA:
                     - distance: Distance analysis (meanDistance, distanceStd, radiusOfGyration, normalizedDistance, exceedanceRatio, threshold, status)
                     - compositeStatus: Combined status ('normal', 'warning', 'danger')
                 - shareUrl: Share URL for the map with this addplot
+            When async_mode=True, a toorpia.job.Job handle is returned instead.
         """
         # Determine target map number
         target_mapNo = mapNo if mapNo is not None else self.mapNo
         if target_mapNo is None:
             print("Error: Map number is not specified. Please provide mapNo or use basemap_csvform() first.")
             return None
-        
+
         # File existence and format check (accept both string and list, same as csvform)
         if isinstance(files, str):
             files = [files]  # Convert single file to list
@@ -942,46 +1032,18 @@ class toorPIA:
             
             headers = {'session-key': self.session_key}  # Content-Type is auto-set by requests
             response = requests.post(
-                f"{API_URL}/data/addplot_csvform", 
+                f"{API_URL}/data/addplot_csvform",
                 files=files_to_upload,
                 data=form_data,
-                headers=headers
+                headers=headers,
+                params=self._async_params(async_mode)
             )
-            
-            if response.status_code == 200:
-                response_data = response.json()
-                addXyData = response_data['resdata']
-                self.currentAddPlotNo = response_data.get('addPlotNo')  # Save addplot number
-                self.shareUrl = response_data.get('shareUrl')  # Save share URL
-                
-                # Convert coordinate data to NumPy array
-                np_array = np.array(addXyData)
-                
-                # Return extended result with coordinate data and abnormality information
-                result = {
-                    'xyData': np_array,
-                    'addPlotNo': self.currentAddPlotNo,
-                    'abnormalityStatus': response_data.get('abnormalityStatus'),  # 'normal', 'abnormal', 'unknown'
-                    'abnormalityScore': response_data.get('abnormalityScore'),    # Abnormality score
-                    'diagnosticScore': response_data.get('diagnosticScore'),     # Composite diagnostic score
-                    'shareUrl': self.shareUrl
-                }
 
-                return result
-            elif response.status_code == 400:
-                print("Error: Bad request. Invalid parameters or missing map.")
-                return None
-            elif response.status_code == 401:
-                print("Error: Unauthorized. Invalid session key or map number.")
-                return None
-            else:
-                try:
-                    error_message = response.json().get('message', 'Unknown error')
-                except:
-                    error_message = f"HTTP {response.status_code}: {response.text}"
-                print(f"CSV addplot failed. Server responded with error: {error_message}")
-                return None
-                
+            if async_mode:
+                return self._handle_job_submission(
+                    response, lambda r: self._handle_addplot_file_response(r, 'csvform'))
+            return self._handle_addplot_file_response(response, 'csvform')
+
         except requests.exceptions.RequestException as e:
             print(f"Network error during file upload: {str(e)}")
             return None
@@ -1003,7 +1065,9 @@ class toorPIA:
                          identna_er_method=None, identna_knn_k=None,
                          # detabn parameters
                          detabn_max_window=5, detabn_rate_threshold=1.0,
-                         detabn_threshold=None, detabn_print_score=True):
+                         detabn_threshold=None, detabn_print_score=True,
+                         # async job mode
+                         async_mode=False):
         """
         Process embedding data for addplot (additional plot) analysis
 
@@ -1028,6 +1092,9 @@ class toorPIA:
             detabn_rate_threshold (float): Rate threshold for abnormality detection
             detabn_threshold (float, optional): Threshold for relative normal area value. When omitted (None), the server auto-derives it from detabn's coverage default (0.90)
             detabn_print_score (bool): Whether to print abnormality score
+            async_mode (bool, optional): If True, submit in the server's asynchronous job
+                mode (?async=true) and return a Job handle immediately instead of blocking.
+                Call job.wait() to get the same return value as the synchronous call. Default: False.
 
         Returns:
             dict: Dictionary containing:
@@ -1040,6 +1107,7 @@ class toorPIA:
                     - distance: Distance analysis (meanDistance, distanceStd, radiusOfGyration, normalizedDistance, exceedanceRatio, threshold, status)
                     - compositeStatus: Combined status ('normal', 'warning', 'danger')
                 - shareUrl: Share URL for the map with this addplot
+            When async_mode=True, a toorpia.job.Job handle is returned instead.
         """
         # Determine target map number
         target_mapNo = mapNo if mapNo is not None else self.mapNo
@@ -1108,41 +1176,13 @@ class toorPIA:
 
             # Send as multipart/form-data to the addplot_embedding endpoint
             # (falls back to uncompressed upload on servers without .csv.gz support)
-            response = self._post_embedding_files('/data/addplot_embedding', files, form_data)
+            response = self._post_embedding_files('/data/addplot_embedding', files, form_data,
+                                                  params=self._async_params(async_mode))
 
-            if response.status_code == 200:
-                response_data = response.json()
-                addXyData = response_data['resdata']
-                self.currentAddPlotNo = response_data.get('addPlotNo')  # Save addplot number
-                self.shareUrl = response_data.get('shareUrl')  # Save share URL
-
-                # Convert coordinate data to NumPy array
-                np_array = np.array(addXyData)
-
-                # Return extended result with coordinate data and abnormality information
-                result = {
-                    'xyData': np_array,
-                    'addPlotNo': self.currentAddPlotNo,
-                    'abnormalityStatus': response_data.get('abnormalityStatus'),  # 'normal', 'abnormal', 'unknown'
-                    'abnormalityScore': response_data.get('abnormalityScore'),    # Abnormality score
-                    'diagnosticScore': response_data.get('diagnosticScore'),     # Composite diagnostic score
-                    'shareUrl': self.shareUrl
-                }
-
-                return result
-            elif response.status_code == 400:
-                print("Error: Bad request. Invalid parameters or missing map.")
-                return None
-            elif response.status_code == 401:
-                print("Error: Unauthorized. Invalid session key or map number.")
-                return None
-            else:
-                try:
-                    error_message = response.json().get('message', 'Unknown error')
-                except:
-                    error_message = f"HTTP {response.status_code}: {response.text}"
-                print(f"Embedding addplot failed. Server responded with error: {error_message}")
-                return None
+            if async_mode:
+                return self._handle_job_submission(
+                    response, lambda r: self._handle_addplot_file_response(r, 'embedding'))
+            return self._handle_addplot_file_response(response, 'embedding')
 
         except requests.exceptions.RequestException as e:
             print(f"Network error during file upload: {str(e)}")
@@ -1158,12 +1198,41 @@ class toorPIA:
                 except:
                     pass
 
+    def _handle_basemap_response(self, response, error_prefix):
+        """basemap_csvform / basemap_waveform / basemap_embedding のレスポンス処理
+        （同期・非同期ジョブ結果の共通処理）
+
+        Args:
+            error_prefix (str): エラーメッセージの先頭に付ける処理名
+        """
+        if response.status_code == 200:
+            response_data = response.json()
+            baseXyData = response_data['resdata']['baseXyData']
+            self.mapNo = response_data['resdata']['mapNo']
+            self.shareUrl = response_data.get('shareUrl')  # Save share URL
+
+            np_array = np.array(baseXyData)  # Convert baseXyData to NumPy array
+
+            # Return unified structure similar to addplot methods
+            return {
+                'xyData': np_array,
+                'mapNo': self.mapNo,
+                'shareUrl': self.shareUrl
+            }
+        else:
+            try:
+                error_message = response.json().get('message', 'Unknown error')
+            except:
+                error_message = f"HTTP {response.status_code}: {response.text}"
+            print(f"{error_prefix}. Server responded with error: {error_message}")
+            return None
+
     @pre_authentication
     def basemap_csvform(self, files, weight_option_str=None, type_option_str=None,
                     drop_columns=None, label=None, tag=None, description=None,
                     random_seed=42, identna_resolution=None, identna_effective_radius=None,
                     identna_er_method=None, identna_knn_k=None,
-                    vector_normalization=None):
+                    vector_normalization=None, async_mode=False):
         """
         Create base map from CSV files directly with unified return structure
         
@@ -1181,37 +1250,41 @@ class toorPIA:
             identna_er_method (str, optional): Bandwidth method when effective_radius="auto": "silverman" (default) or "knn"
             identna_knn_k (int, optional): k for knn method (0 = auto ceil(sqrt(n)))
             vector_normalization (bool, optional): Enable/disable L2 vector normalization in the toorpia binary. Default server-side is True. Pass False to disable (adds the `-u` flag). The chosen value is persisted on the basemap and inherited by subsequent addplot calls.
+            async_mode (bool, optional): If True, submit in the server's asynchronous job
+                mode (?async=true) and return a Job handle immediately instead of blocking.
+                Call job.wait() to get the same return value as the synchronous call. Default: False.
 
         Returns:
             dict: Dictionary containing:
                 - xyData: Coordinate data as NumPy array (each row is [x, y])
                 - mapNo: Map number
                 - shareUrl: Share URL for the map
+            When async_mode=True, a toorpia.job.Job handle is returned instead.
         """
         # File existence and format check (accept both string and list)
         if isinstance(files, str):
             files = [files]  # Convert single file to list
-        
+
         if not files or not isinstance(files, list):
             print("Error: files must be a file path (string) or list of file paths")
             return None
-        
+
         files_to_upload = []
         for file_path in files:
             if not os.path.exists(file_path):
                 print(f"Error: File not found: {file_path}")
                 return None
-            
+
             # File format check (.csv only)
             ext = os.path.splitext(file_path)[1].lower()
             if ext != '.csv':
                 print(f"Error: Unsupported file format: {ext}. Only .csv files are supported.")
                 return None
-            
+
             files_to_upload.append(('files', open(file_path, 'rb')))
-        
+
         try:
-            # Prepare form data 
+            # Prepare form data
             form_data = {
                 'label': label or '',
                 'tag': tag or '',
@@ -1254,31 +1327,15 @@ class toorPIA:
                 f"{API_URL}/data/basemap_csvform",
                 files=files_to_upload,
                 data=form_data,
-                headers=headers
+                headers=headers,
+                params=self._async_params(async_mode)
             )
-            
-            if response.status_code == 200:
-                response_data = response.json()
-                baseXyData = response_data['resdata']['baseXyData']
-                self.mapNo = response_data['resdata']['mapNo']
-                self.shareUrl = response_data.get('shareUrl')  # Save share URL
-                
-                np_array = np.array(baseXyData)  # Convert baseXyData to NumPy array
-                
-                # Return unified structure similar to addplot methods
-                return {
-                    'xyData': np_array,
-                    'mapNo': self.mapNo,
-                    'shareUrl': self.shareUrl
-                }
-            else:
-                try:
-                    error_message = response.json().get('message', 'Unknown error')
-                except:
-                    error_message = f"HTTP {response.status_code}: {response.text}"
-                print(f"CSV basemap creation failed. Server responded with error: {error_message}")
-                return None
-                
+
+            if async_mode:
+                return self._handle_job_submission(
+                    response, lambda r: self._handle_basemap_response(r, 'CSV basemap creation failed'))
+            return self._handle_basemap_response(response, 'CSV basemap creation failed')
+
         except requests.exceptions.RequestException as e:
             print(f"Network error during CSV file upload: {str(e)}")
             return None
@@ -1297,7 +1354,7 @@ class toorPIA:
     def basemap_embedding(self, files, l2_normalization=None, id_columns=None,
                     label=None, tag=None, description=None,
                     identna_resolution=None, identna_effective_radius=None,
-                    identna_er_method=None, identna_knn_k=None):
+                    identna_er_method=None, identna_knn_k=None, async_mode=False):
         """
         Create base map from embedding vectors with unified return structure
 
@@ -1328,12 +1385,16 @@ class toorPIA:
             identna_effective_radius (float or "auto", optional): Effective radius. "auto" for automatic determination (default: 0.1)
             identna_er_method (str, optional): Bandwidth method when effective_radius="auto": "silverman" (default) or "knn"
             identna_knn_k (int, optional): k for knn method (0 = auto ceil(sqrt(n)))
+            async_mode (bool, optional): If True, submit in the server's asynchronous job
+                mode (?async=true) and return a Job handle immediately instead of blocking.
+                Call job.wait() to get the same return value as the synchronous call. Default: False.
 
         Returns:
             dict: Dictionary containing:
                 - xyData: Coordinate data as NumPy array (each row is [x, y])
                 - mapNo: Map number
                 - shareUrl: Share URL for the map
+            When async_mode=True, a toorpia.job.Job handle is returned instead.
         """
         # ndarray/DataFrame direct input: convert to a temporary CSV file
         temp_csv_path = None
@@ -1392,29 +1453,13 @@ class toorPIA:
 
             # Send as multipart/form-data to the basemap_embedding endpoint
             # (falls back to uncompressed upload on servers without .csv.gz support)
-            response = self._post_embedding_files('/data/basemap_embedding', files, form_data)
+            response = self._post_embedding_files('/data/basemap_embedding', files, form_data,
+                                                  params=self._async_params(async_mode))
 
-            if response.status_code == 200:
-                response_data = response.json()
-                baseXyData = response_data['resdata']['baseXyData']
-                self.mapNo = response_data['resdata']['mapNo']
-                self.shareUrl = response_data.get('shareUrl')  # Save share URL
-
-                np_array = np.array(baseXyData)  # Convert baseXyData to NumPy array
-
-                # Return unified structure similar to addplot methods
-                return {
-                    'xyData': np_array,
-                    'mapNo': self.mapNo,
-                    'shareUrl': self.shareUrl
-                }
-            else:
-                try:
-                    error_message = response.json().get('message', 'Unknown error')
-                except:
-                    error_message = f"HTTP {response.status_code}: {response.text}"
-                print(f"Embedding basemap creation failed. Server responded with error: {error_message}")
-                return None
+            if async_mode:
+                return self._handle_job_submission(
+                    response, lambda r: self._handle_basemap_response(r, 'Embedding basemap creation failed'))
+            return self._handle_basemap_response(response, 'Embedding basemap creation failed')
 
         except requests.exceptions.RequestException as e:
             print(f"Network error during embedding CSV upload: {str(e)}")
@@ -1442,7 +1487,9 @@ class toorPIA:
                         # toorpia binary option
                         vector_normalization=None,
                         # metadata
-                        label=None, tag=None, description=None):
+                        label=None, tag=None, description=None,
+                        # async job mode
+                        async_mode=False):
         """
         Create base map from WAV or CSV files directly with unified return structure
         
@@ -1464,12 +1511,16 @@ class toorPIA:
             label (str): Map label
             tag (str): Map tag
             description (str): Map description
+            async_mode (bool, optional): If True, submit in the server's asynchronous job
+                mode (?async=true) and return a Job handle immediately instead of blocking.
+                Call job.wait() to get the same return value as the synchronous call. Default: False.
 
         Returns:
             dict: Dictionary containing:
                 - xyData: Coordinate data as NumPy array (each row is [x, y])
                 - mapNo: Map number
                 - shareUrl: Share URL for the map
+            When async_mode=True, a toorpia.job.Job handle is returned instead.
         """
         # File existence and format check
         if not files or not isinstance(files, list):
@@ -1532,31 +1583,15 @@ class toorPIA:
                 f"{API_URL}/data/basemap_waveform",
                 files=files_to_upload,
                 data=form_data,
-                headers=headers
+                headers=headers,
+                params=self._async_params(async_mode)
             )
-            
-            if response.status_code == 200:
-                response_data = response.json()
-                baseXyData = response_data['resdata']['baseXyData']
-                self.mapNo = response_data['resdata']['mapNo']
-                self.shareUrl = response_data.get('shareUrl')  # Save share URL
-                
-                np_array = np.array(baseXyData)  # Convert baseXyData to NumPy array
-                
-                # Return unified structure similar to addplot methods
-                return {
-                    'xyData': np_array,
-                    'mapNo': self.mapNo,
-                    'shareUrl': self.shareUrl
-                }
-            else:
-                try:
-                    error_message = response.json().get('message', 'Unknown error')
-                except:
-                    error_message = f"HTTP {response.status_code}: {response.text}"
-                print(f"Waveform basemap creation failed. Server responded with error: {error_message}")
-                return None
-                
+
+            if async_mode:
+                return self._handle_job_submission(
+                    response, lambda r: self._handle_basemap_response(r, 'Waveform basemap creation failed'))
+            return self._handle_basemap_response(response, 'Waveform basemap creation failed')
+
         except requests.exceptions.RequestException as e:
             print(f"Network error during file upload: {str(e)}")
             return None
@@ -1910,7 +1945,7 @@ class toorPIA:
                     pass
             return None
 
-    def _post_embedding_files(self, endpoint, file_paths, form_data):
+    def _post_embedding_files(self, endpoint, file_paths, form_data, params=None):
         """
         POST embedding CSV files (.csv / .csv.gz) to an embedding endpoint as
         multipart/form-data.
@@ -1924,6 +1959,7 @@ class toorPIA:
             endpoint (str): Endpoint path (e.g. "/data/basemap_embedding")
             file_paths (list): Paths of the CSV files to upload
             form_data (dict): Additional form fields
+            params (dict, optional): Query parameters (e.g. {'async': 'true'})
 
         Returns:
             requests.Response: The server response (of the retry, if one occurred)
@@ -1934,7 +1970,7 @@ class toorPIA:
             handles = [('files', open(p, 'rb')) for p in paths]
             try:
                 return requests.post(f"{API_URL}{endpoint}", files=handles,
-                                     data=form_data, headers=headers)
+                                     data=form_data, headers=headers, params=params)
             finally:
                 for _, handle in handles:
                     try:

--- a/toorpia/job.py
+++ b/toorpia/job.py
@@ -1,0 +1,116 @@
+import json
+import time
+
+
+class _JobHttpResponse:
+    """ジョブ結果 (httpStatus + body) を requests.Response 互換の形に包む薄いラッパ
+
+    非同期ジョブの result / error は同期実行時のレスポンスボディと同形なので、
+    これで包むことで同期用のレスポンス処理ロジックをそのまま流用できる。
+    """
+
+    def __init__(self, status_code, body):
+        self.status_code = status_code if status_code is not None else 500
+        self._body = body if body is not None else {}
+
+    def json(self):
+        return self._body
+
+    @property
+    def text(self):
+        return json.dumps(self._body, ensure_ascii=False)
+
+
+class Job:
+    """?async=true で投入した非同期ジョブのハンドル
+
+    fit_transform / addplot / basemap_* / addplot_* 系メソッドに async_mode=True を
+    渡すと返される。wait() で完了までポーリングすると、同期実行時と同じ形の
+    返り値が得られる（client.mapNo などの属性更新も同期実行時と同様に行われる）。
+
+    Example:
+        job = client.basemap_csvform(["data.csv"], async_mode=True)
+        result = job.wait()  # {'xyData': ..., 'mapNo': ..., 'shareUrl': ...}
+    """
+
+    # wait() がポーリング失敗（ネットワークエラー・404等）を連続で許容する回数
+    MAX_CONSECUTIVE_POLL_FAILURES = 3
+
+    def __init__(self, client, job_id, parser, job_type=None):
+        self.client = client
+        self.job_id = job_id
+        self.type = job_type
+        self.status = 'queued'
+        self.raw = None  # 直近の GET /jobs/:jobId レスポンスボディ
+        self._parser = parser
+        self._result = None
+        self._parsed = False
+
+    def __repr__(self):
+        return f"<toorPIA Job {self.job_id} type={self.type} status={self.status}>"
+
+    def refresh(self):
+        """ジョブの現在の状態を1回問い合わせて反映する
+
+        Returns:
+            str: 現在のステータス ('queued', 'running', 'done', 'failed')。
+                 問い合わせに失敗した場合は None
+        """
+        info = self.client.get_job(self.job_id)
+        if info is None:
+            return None
+        self.raw = info
+        self.status = info.get('status', self.status)
+        self.type = info.get('type', self.type)
+        return self.status
+
+    @property
+    def finished(self):
+        return self.status in ('done', 'failed')
+
+    def result(self):
+        """完了済みジョブの結果を同期実行時と同じ形で返す
+
+        未完了の場合は一度だけ状態を更新し、それでも未完了なら None を返す。
+        failed の場合も同期実行時と同様にエラーメッセージを表示して None を返す。
+        """
+        if not self.finished:
+            self.refresh()
+        if not self.finished:
+            print(f"Job {self.job_id} is not finished yet (status: {self.status}).")
+            return None
+        if not self._parsed:
+            body = self.raw.get('result') if self.status == 'done' else self.raw.get('error')
+            self._result = self._parser(_JobHttpResponse(self.raw.get('httpStatus'), body))
+            self._parsed = True
+        return self._result
+
+    def wait(self, poll_interval=5, timeout=None):
+        """完了までポーリングし、同期実行時と同じ形の結果を返す
+
+        Args:
+            poll_interval (float): ポーリング間隔（秒、デフォルト5秒）
+            timeout (float, optional): 最大待ち時間（秒）。None で無制限。
+                超過してもジョブ自体はサーバー側で継続し、後から result() や
+                client.get_job() で結果を取得できる（結果保持は完了後24時間）
+
+        Returns:
+            同期実行時と同じ返り値。タイムアウトまたはジョブ失敗時は None
+        """
+        start = time.monotonic()
+        failures = 0
+        while True:
+            status = self.refresh()
+            if status is None:
+                failures += 1
+                if failures >= self.MAX_CONSECUTIVE_POLL_FAILURES:
+                    print(f"Error: Failed to poll job {self.job_id} {failures} times in a row. Giving up.")
+                    return None
+            else:
+                failures = 0
+                if self.finished:
+                    return self.result()
+            if timeout is not None and time.monotonic() - start >= timeout:
+                print(f"Timeout: Job {self.job_id} did not finish within {timeout} seconds (status: {self.status}).")
+                return None
+            time.sleep(poll_interval)


### PR DESCRIPTION
## 概要

backend の非同期ジョブモード（`?async=true` + `GET /jobs/:jobId`、backend issue #125）にクライアントを対応させます。数万点規模のデータでエンジン処理が数分かかる場合でも、プロキシ / LB のアイドルタイムアウトによる切断で結果（mapNo・addPlotNo・異常判定）を取りこぼさなくなります。

## 使い方

```python
job = client.basemap_csvform(["large_data.csv"], async_mode=True)  # 202 + jobId で即座に Job が返る
result = job.wait()   # ポーリングして完了後、同期実行時とまったく同じ返り値
```

ノンブロッキング利用は `job.refresh()` / `job.status` / `job.finished` / `job.result()`。生のジョブ情報は `client.get_job(job_id)`（結果は完了後24時間保持、後からの再取得可）。

## 変更内容

- **`toorpia/job.py`（新規）**: `Job` ハンドル。ジョブの `result` / `error` が同期実行時のレスポンスボディと同形であることを利用し、requests.Response 互換ラッパで同期用レスポンス処理を流用。`wait(poll_interval=5, timeout=None)`、ポーリング連続失敗時（3回）の打ち切り付き
- **`toorpia/client.py`**:
  - 8メソッド（`fit_transform`, `addplot`, `basemap_csvform/waveform/embedding`, `addplot_csvform/waveform/embedding`）に `async_mode=False` を追加（`async` は予約語のため）
  - 各メソッドのレスポンス処理を同期・非同期共通ハンドラ（`_handle_fit_transform_response` / `_handle_basemap_response` / `_handle_addplot_response` / `_handle_addplot_file_response`）に集約
  - `get_job()`: ポーリング中のセッション切れを一度だけ再認証してリカバリ
  - async 未対応の旧サーバーへのフォールバック（`?async=true` が無視され 200 が返った場合は同期結果をそのまま返す）
  - `pre_authentication` に `functools.wraps` を適用（`help()` / IDE でシグネチャ・docstring が見えるように）
- **ドキュメント**: README「Asynchronous Job Mode」、`docs/api-reference.md` セクション追加、`docs/release-notes/v1.3.0_jp.md`
- **テスト**: `test_fit_transform_async` / `test_addplot_async` を追加
- **バージョン**: 1.2.0 → 1.3.0

## 後方互換性

- `async_mode` 既定値は `False` で、未指定時のリクエスト・挙動は完全に従来どおり
- 廃止予定の `fit_transform_waveform` / `fit_transform_csvform` には追加せず（後継の `basemap_*` を案内）

## テスト

- モックテスト7件（投入→ポーリング→結果解析 / 失敗ジョブ / 429 / 旧サーバーフォールバック / 401再認証 / ポーリング連続失敗打ち切り / 同期パス無変更確認）すべてパス
- 実サーバ（api.toorpia.com）E2E: `fit_transform` 非同期投入 約2秒で202 → `job.wait()` で座標取得、`addplot` 非同期も異常判定込みで正常動作
- 既存スイート: 5件パス。失敗4件（export/import/checksum系）は本PRと無関係の既存問題（`calculate_checksum` がHEADに存在しない等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)