### PR TITLE
docs: PEP 668 (externally-managed-environment) エラーの対処方法を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ Or install the latest development version directly from GitHub:
 pip install git+https://github.com/toorpia/toorpia.git
 ```
 
+> **Note (Debian 12+ / Ubuntu 23.04+ / Raspberry Pi OS):** If `pip install` fails with
+> an `externally-managed-environment` error (PEP 668), install into a virtual
+> environment instead:
+>
+> ```bash
+> python3 -m venv ~/toorpia-venv
+> ~/toorpia-venv/bin/pip install toorpia
+> ```
+>
+> See [Troubleshooting](docs/troubleshooting.md#externally-managed-environment-error-pep-668) for details.
+
 ### Core Workflow: Basemap → Addplot Analysis
 
 toorPIA follows a simple two-step workflow for data analysis and anomaly detection:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,6 +49,55 @@ This document explains potential issues that may occur when using toorPIA and th
    pip install git+https://github.com/toorpia/toorpia.git --force-reinstall
    ```
 
+### `externally-managed-environment` Error (PEP 668)
+
+**Symptoms**: `pip install toorpia` fails with:
+
+```
+error: externally-managed-environment
+
+× This environment is externally managed
+╰─> To install Python packages system-wide, try apt install
+    python3-xyz, ...
+```
+
+**Cause**: This is not a problem with the toorpia package. On Debian 12+, Ubuntu 23.04+,
+and Raspberry Pi OS (Bookworm and later), the OS-managed system Python blocks direct
+`pip` installs ([PEP 668](https://peps.python.org/pep-0668/)) to prevent conflicts with
+apt-managed packages.
+
+**Solutions**:
+
+1. **Use a virtual environment (recommended)**
+   ```bash
+   python3 -m venv ~/toorpia-venv
+   ~/toorpia-venv/bin/pip install toorpia
+
+   # Interactive use
+   source ~/toorpia-venv/bin/activate
+   python your_script.py
+
+   # Or run directly without activation (recommended for cron / systemd)
+   ~/toorpia-venv/bin/python your_script.py
+   ```
+
+   For monitoring scripts on edge devices (Raspberry Pi / RevPi etc.), reference the
+   venv's Python by absolute path in your cron job or systemd unit, e.g.
+   `ExecStart=/home/pi/toorpia-venv/bin/python /home/pi/monitor.py`.
+
+   If venv creation fails, install the venv support packages first:
+   ```bash
+   sudo apt install python3-full python3-venv
+   ```
+
+2. **User-site install (single-purpose devices)**
+   ```bash
+   pip3 install --user --break-system-packages toorpia
+   ```
+   This installs into `~/.local` without touching system directories. Avoid
+   `sudo pip3 install --break-system-packages` (system-wide override), which can
+   break OS-managed Python packages.
+
 ### Environment Variables Not Recognized
 
 **Symptoms**: API key error occurs despite setting `TOORPIA_API_KEY`


### PR DESCRIPTION
## 概要

Debian 12+ / Ubuntu 23.04+ / Raspberry Pi OS (Bookworm以降) で `pip install toorpia` を実行すると PEP 668 により `externally-managed-environment` エラーになります（パッケージ側の問題ではなく、OS管理のシステムPythonの保護機構）。実機で遭遇したため、顧客向けに対処方法をドキュメント化します。

## 変更内容

- **`docs/troubleshooting.md`**: 「externally-managed-environment Error (PEP 668)」セクションを追加
  - venv を使ったインストール手順（推奨）。エッジデバイス（RasPi / RevPi）の cron / systemd から venv の Python を絶対パスで実行する例を含む
  - 単一用途デバイス向けの次善策 `pip3 install --user --break-system-packages`（`sudo` での system-wide 上書きは非推奨と明記）
  - venv 作成に失敗する場合の `apt install python3-full python3-venv`
- **`README.md`**: Installation セクションに注記と troubleshooting へのリンクを追加

ドキュメントのみの変更のため、バージョン更新・リリースは行いません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)