### PR TITLE
feat: 保存済みベースマップのXY座標を取得する get_map_xy() を追加

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -801,6 +801,36 @@ The returned map data includes the following metadata in addition to the basic i
 - `tag`: Classification tag for the map
 - `description`: Detailed description of the map
 
+### get_map_xy()
+
+Retrieves the XY coordinate data of a saved basemap. This returns the same coordinates that were included in the map-creation response (`basemap_*` / `fit_transform` methods), so you can re-fetch them at any time without re-running the analysis.
+
+```python
+# Get XY coordinates of the current map
+xy_info = client.get_map_xy()
+
+# Or specify a map number explicitly
+xy_info = client.get_map_xy(map_no=123)
+
+# Access the coordinate data
+xy_data = xy_info['xyData']          # NumPy array of [x, y] coordinates
+share_url = xy_info['shareUrl']      # Share URL for this map
+print(f"Map #{xy_info['mapNo']}: {xy_info['nRecord']} records")
+```
+
+**Returns** a dictionary with the following keys (or `None` on failure):
+- `mapNo`: Map number
+- `nRecord`: Number of records
+- `nDimension`: Number of dimensions of the original data
+- `processMethod`: How the map was created (`"dataframe"` | `"csvform"` | `"waveform"` | `"embedding"`; `None` for maps created with older versions)
+- `xyData`: NumPy array of coordinates (each row is an `[x, y]` pair)
+- `shareUrl`: Share URL for the map
+
+**Notes**:
+- Retrieving XY data does not consume the hourly analysis task quota (rate limit) — it is a read-only endpoint.
+- The XY coordinates of a saved add plot can be retrieved with [get_addplot()](#get_addplot).
+- Requires a backend version that supports the `GET /maps/{mapNo}/xy` endpoint.
+
 ### export_map()
 
 Exports a map to a specified directory, including all base map files and the `input/` subdirectory if present.

--- a/toorpia/client.py
+++ b/toorpia/client.py
@@ -766,6 +766,62 @@ class toorPIA:
             return None
 
     @pre_authentication
+    def get_map_xy(self, map_no=None):
+        """
+        保存済みベースマップのXY座標データを取得する
+
+        マップ生成時（basemap_*系/fit_transform系）のレスポンスに含まれる座標データと
+        同じものを、生成後いつでも再取得できます。
+
+        Note: バックエンドのエンドポイント GET /maps/{mapNo}/xy を使用します。
+        この機能に対応していない旧バージョンのバックエンドではエラーになります。
+
+        Args:
+            map_no (int, optional): マップ番号。指定がない場合は現在のマップ番号を使用
+
+        Returns:
+            dict: ベースマップのXY座標情報を含む辞書。以下のキーを含みます：
+                - mapNo: マップ番号
+                - nRecord: レコード数
+                - nDimension: 次元数
+                - processMethod: マップの作成方式
+                      "dataframe" | "csvform" | "waveform" | "embedding"
+                      （旧バージョンで作成されたマップではNone）
+                - xyData: 座標データのNumPy配列（各行は[x, y]座標）
+                - shareUrl: マップの共有URL
+
+            取得に失敗した場合はNoneを返す
+        """
+        if map_no is None:
+            if self.mapNo is None:
+                print("Error: Map number is not specified. Please provide a map_no or use fit_transform() first.")
+                return None
+            map_no = self.mapNo
+
+        headers = {'Content-Type': 'application/json', 'session-key': self.session_key}
+        response = requests.get(f"{API_URL}/maps/{map_no}/xy", headers=headers)
+        if response.status_code == 200:
+            result = response.json()
+            self.shareUrl = result.get('shareUrl')
+            # NumPy配列に変換して返す
+            np_array = np.array(result.get('xyData', []))
+            return {
+                'mapNo': result.get('mapNo'),
+                'nRecord': result.get('nRecord'),
+                'nDimension': result.get('nDimension'),
+                'processMethod': result.get('processMethod'),
+                'xyData': np_array,
+                'shareUrl': self.shareUrl
+            }
+        else:
+            try:
+                error_message = response.json().get('message', 'Unknown error')
+            except Exception:
+                error_message = f"HTTP {response.status_code}"
+            print(f"Failed to get map XY data. Server responded with error: {error_message}")
+            return None
+
+    @pre_authentication
     def export_map(self, map_no, export_dir):
         """
         指定されたマップをエクスポート（ダウンロード）し、指定されたディレクトリに保存する


### PR DESCRIPTION
## 概要

保存済みベースマップのXY座標データを取得する `get_map_xy()` メソッドを追加します。

これまでベースマップのXY座標はマップ生成時（`basemap_*` / `fit_transform` 系）のレスポンスでしか取得できず、保存済みマップから座標だけを再取得する手段がありませんでした（`export_map` はファイル一式のダウンロードで用途が異なります）。addplot 側には既に `get_addplot()` があるため、basemap 側にも対称な取得手段を設けます。

## 変更内容

- `toorpia/client.py`: `get_map_xy(map_no=None)` を追加
  - バックエンドの `GET /maps/{mapNo}/xy` を呼び出し、`{mapNo, nRecord, nDimension, processMethod, xyData, shareUrl}` を返す
  - `xyData` は NumPy 配列（各行が `[x, y]`）。生成時レスポンスの座標データと同一内容
  - `map_no` 省略時は現在のマップ番号（`client.mapNo`）を使用（`get_addplot_features()` と同じ流儀）
  - 失敗時は `None` を返しエラーメッセージを表示（既存メソッドと同じエラーハンドリング）
- `docs/api-reference.md`: Map Management セクションに `get_map_xy()` の使用例と戻り値の説明を追記

## 使用例

```python
xy_info = client.get_map_xy(map_no=123)
xy_data = xy_info['xyData']  # NumPy array of [x, y] coordinates
```

## 備考

- XY座標の取得は閲覧系のため、解析タスクの時間あたり実行数制限（rate limit）を消費しません
- 対応するエンドポイントを持たない旧バージョンのバックエンドではエラーになります（バックエンド側PR: toorpia/backend#141）

🤖 Generated with [Claude Code](https://claude.com/claude-code)