### PR TITLE
feat(mcp): 保存済みマップの分布要約を返す describe_map ツールを追加

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -14,6 +14,7 @@ The server runs locally on your machine (stdio transport), reads embedding CSV f
 | `create_basemap` | Upload baseline embeddings and build the 2-D reference map. Returns `mapNo`, `shareUrl`, and a distribution summary. |
 | `add_plot` | Project new embeddings onto an existing map and run anomaly detection. Returns abnormality status/score, a composite diagnostic (normal / warning / danger), and `shareUrl`. |
 | `list_maps` | List the maps that belong to your API key (newest first). |
+| `describe_map` | Statistical summary of a saved map's 2-D distribution (point count, ranges, centroid, radius of gyration, outlier/cluster estimates) plus metadata and `shareUrl` — without re-processing anything. |
 
 ### Input data format
 
@@ -123,7 +124,7 @@ npx @modelcontextprotocol/inspector \
 Then in the Inspector UI that opens in your browser:
 
 1. Press **Connect** — the server banner should appear in the console (`[toorpia-mcp] server started`)
-2. Open **Tools → List Tools** — the four tools should be listed
+2. Open **Tools → List Tools** — the five tools should be listed
 3. Call `preview_csv` with `{"path": "<absolute path>/testdata/embedding_sample.csv"}` — returns row/dimension statistics without touching the API
 4. Call `list_maps` with `{}` — verifies authentication against the API (`AUTH_FAILED` here means the API key is wrong)
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toorpia/mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for toorPIA embedding analysis: deterministic dimensionality reduction and anomaly detection for embedding vectors",
   "license": "MIT",
   "type": "module",

--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -44,6 +44,15 @@ export interface MapInfo {
   shareUrl?: string | null;
 }
 
+export interface MapXyResult {
+  mapNo: number;
+  nRecord: number | null;
+  nDimension: number | null;
+  processMethod: string | null;
+  xyData: number[][];
+  shareUrl: string | null;
+}
+
 // Basemap creation on large embedding sets can take minutes; disable the
 // default 5-minute undici header timeout and rely on a generous cap instead.
 const LONG_REQUEST_AGENT = new Agent({
@@ -331,5 +340,39 @@ export class ToorpiaApi {
       );
     }
     return js as MapInfo[];
+  }
+
+  /** Fetch the stored 2-D coordinates of a saved basemap (GET /maps/{mapNo}/xy). */
+  async getMapXy(mapNo: number): Promise<MapXyResult> {
+    const res = await this.request(`/maps/${mapNo}/xy`, () => ({ method: "GET" }));
+    if (res.status === 404) {
+      throw await this.apiError(
+        res,
+        `Fetching XY data for map ${mapNo}`,
+        `Either map ${mapNo} does not exist under this API key (call list_maps to see the available maps), or the toorPIA API server predates the GET /maps/{mapNo}/xy endpoint — on such servers this call fails for every map.`,
+      );
+    }
+    if (!res.ok) {
+      throw await this.apiError(
+        res,
+        `Fetching XY data for map ${mapNo}`,
+        "Retry once; if it keeps failing, the toorPIA API server may be unavailable.",
+      );
+    }
+    const js: any = await res.json().catch(() => ({}));
+    if (!Array.isArray(js?.xyData)) {
+      throw new ToolError(
+        "INVALID_RESPONSE",
+        `The toorPIA API returned an unexpected response for GET /maps/${mapNo}/xy. Verify that TOORPIA_API_URL (${this.apiUrl}) points to a toorPIA API server that supports this endpoint.`,
+      );
+    }
+    return {
+      mapNo: typeof js.mapNo === "number" ? js.mapNo : mapNo,
+      nRecord: js?.nRecord ?? null,
+      nDimension: js?.nDimension ?? null,
+      processMethod: js?.processMethod ?? null,
+      xyData: js.xyData as number[][],
+      shareUrl: js?.shareUrl ?? null,
+    };
   }
 }

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -6,7 +6,7 @@ import { previewEmbeddingCsv } from "./preview.js";
 import { summarizeXy } from "./summary.js";
 import { ToolError, toErrorPayload } from "./errors.js";
 
-const SERVER_VERSION = "0.1.0";
+const SERVER_VERSION = "0.2.0";
 
 const INSTRUCTIONS = `toorPIA is a dimensionality-reduction and anomaly-detection service built on an O(n) Laplacian-eigenmaps implementation. Unlike t-SNE/UMAP, results are deterministic and stable across runs, and new data points can be added to an existing map without recomputation, preserving coordinate consistency. This server is specialized for EMBEDDING vectors — LLM sentence/document embeddings, image features, audio embeddings, or any fixed-dimensional numeric vectors — stored as CSV files (rows = samples, columns = dimensions; .csv or .csv.gz).
 
@@ -17,6 +17,7 @@ Typical workflow:
 2. create_basemap — upload baseline embeddings and build the reference map
 3. add_plot — project new embeddings onto an existing map and get an anomaly verdict
 4. list_maps — find previously created maps to reuse
+5. describe_map — statistical summary of a saved map's 2-D distribution (e.g. before reusing it with add_plot)
 
 Raw 2-D coordinates are summarized, never returned in full; direct the user to the returned shareUrl to explore the map interactively in a browser.`;
 
@@ -250,6 +251,40 @@ export async function startServer(): Promise<void> {
           totalMaps: maps.length,
           shown: shown.length,
           maps: shown,
+        };
+      }),
+  );
+
+  server.registerTool(
+    "describe_map",
+    {
+      title: "Describe a saved map",
+      description:
+        "Fetch the stored 2-D coordinates of an existing basemap and return a statistical summary of its distribution (point count, coordinate ranges, centroid, radius of gyration, outlier/cluster estimates) together with the map's metadata and shareUrl — without re-uploading or re-processing anything. Use this to inspect a map created in an earlier session before deciding to add_plot onto it, or to compare the distributions of existing maps. Works for any map regardless of how it was created; check the returned processMethod — add_plot from this server only works on embedding maps. Read-only and does not consume the hourly analysis quota.",
+      inputSchema: {
+        mapNo: z.number().int().optional()
+          .describe("Map number to describe. Defaults to the map most recently created by create_basemap in this session. When unsure, call list_maps first."),
+      },
+    },
+    async ({ mapNo: mapNoArg }) =>
+      runTool("describe_map", async () => {
+        const mapNo = mapNoArg ?? api.lastMapNo;
+        if (mapNo == null) {
+          throw new ToolError(
+            "MAP_NO_REQUIRED",
+            "No target map: mapNo was not given and no basemap has been created in this server session. Call list_maps, pick a map, and pass its mapNo explicitly.",
+          );
+        }
+        const result = await api.getMapXy(mapNo);
+        return {
+          ok: true,
+          mapNo: result.mapNo,
+          nRecord: result.nRecord,
+          nDimension: result.nDimension,
+          processMethod: result.processMethod,
+          xySummary: summarizeXy(result.xyData),
+          shareUrl: result.shareUrl,
+          hint: "Share the shareUrl with the user for interactive exploration (full coordinates are never returned to the model). If processMethod is \"embedding\", new embedding batches can be tested against this map with add_plot.",
         };
       }),
   );


### PR DESCRIPTION
## 概要

MCPサーバに5つ目のツール `describe_map(mapNo)` を追加します。保存済みマップのXY座標をバックエンドから取得し、既存の `summarizeXy` でローカル統計要約（点数・座標範囲・重心・radius of gyration・外れ値/クラスタ推定）して、マップのメタデータ・`shareUrl` と共に返します。

## 背景

これまでMCPからは `create_basemap` 実行時にしか分布要約（`xySummary`）を得られず、過去のセッションで作成したマップについては `list_maps` のメタデータ以上の情報を再取得できませんでした。バックエンドに座標再取得エンドポイント `GET /maps/{mapNo}/xy` が追加されたことで、「セッションをまたいで過去のマップを吟味してから `add_plot` する」ワークフローが完結できるようになります。座標取得は閲覧系のため、解析タスクの時間あたり実行数制限を消費しません。

## 変更内容

- `mcp/src/api.ts`: `getMapXy(mapNo)` を追加。404時は「マップ不在」と「旧サーバでエンドポイント未対応」の両方の可能性をLLM向けに案内
- `mcp/src/server.ts`: `describe_map` ツールを登録
  - `mapNo` 省略時はセッション内で最後に作成したマップ（`add_plot` と同じ流儀）
  - 全点座標をモデルコンテキストに入れない従来方針を踏襲（要約のみ返却）
  - どの作成方式のマップでも動作。`add_plot` 可否（embeddingマップのみ）の判断材料として `processMethod` を返却
  - INSTRUCTIONS のワークフロー説明に手順5として追記
- `mcp/README.md`: ツール表と MCP Inspector の確認手順を5ツール構成に更新
- `mcp/package.json` / `SERVER_VERSION`: 0.1.0 → 0.2.0

## E2E（api.toorpia.com、MCPプロトコル経由）

- `tools/list`: 5ツール（`preview_csv` / `create_basemap` / `add_plot` / `list_maps` / `describe_map`）の登録を確認
- `describe_map(1860)`: 10点マップの要約取得OK（nPoints=nRecord=10、重心≈原点、Rg等）
- `describe_map(1702)`: 10000点マップで全点要約OK（nPoints=nRecord=10000）
- `describe_map(999999)`: 存在しないマップで `API_ERROR`（`isError: true`）の適切な応答を確認

## 備考

- 対応する `GET /maps/{mapNo}/xy` を持たない旧バージョンのAPIサーバでは、`describe_map` はエラーメッセージでその可能性を案内します（他の4ツールは影響なし）
- npm への公開（@toorpia/mcp 0.2.0）は別途リリース作業にて

🤖 Generated with [Claude Code](https://claude.com/claude-code)