### PR TITLE
chore: v1.4.0 リリース準備

### DIFF
--- a/docs/release-notes/v1.4.0_jp.md
+++ b/docs/release-notes/v1.4.0_jp.md
@@ -1,0 +1,28 @@
+# toorPIA Python Client v1.4.0 リリースノート
+
+**リリース日:** 2026-07-31
+
+## 主な変更 (v1.3.0 以降)
+
+### 新機能 (feat)
+
+- **保存済みベースマップのXY座標を取得する `get_map_xy()` を追加**
+  - `client.get_map_xy(map_no=None)` で、保存済みベースマップのXY座標データを生成後いつでも再取得できます。マップ生成時（`basemap_*` / `fit_transform` 系）のレスポンスに含まれる座標データと同一の内容が得られます。
+  - `map_no` 省略時は現在のマップ番号（`client.mapNo`）を使用します（`get_addplot_features()` と同じ流儀）。
+  - 返り値は辞書 `{mapNo, nRecord, nDimension, processMethod, xyData, shareUrl}`。`xyData` は NumPy 配列（各行が `[x, y]`）で、失敗時は従来メソッドと同様にエラーメッセージを表示して `None` を返します。
+  - 座標取得は閲覧系のため、解析タスクの時間あたり実行数制限（rate limit）を消費しません。
+  - 保存済み追加プロット（addplot）のXY座標は従来どおり `get_addplot()` のレスポンス `xyData` で取得できます。
+  - 利用には `GET /maps/{mapNo}/xy` エンドポイント対応版の toorPIA backend が必要です（api.toorpia.com は対応済み）。旧サーバではエラーメッセージを表示して `None` を返します。
+
+### ドキュメント
+
+- `docs/api-reference.md`: Map Management セクションに `get_map_xy()` の使用例と戻り値の説明を追加
+- `README.md` / `docs/troubleshooting.md`: PEP 668 (externally-managed-environment) エラーが出る環境でのインストール方法を追記
+
+### その他（PyPI パッケージ対象外）
+
+- MCP サーバ（`@toorpia/mcp` 0.2.0、npm で別途配布）に、保存済みマップの分布統計要約を返す `describe_map` ツールを追加しました。本リポジトリの `mcp/` 配下の変更であり、PyPI の `toorpia` パッケージには含まれません。
+
+## 後方互換性
+
+- 変更は新メソッド `get_map_xy()` の追加のみで、既存メソッドのシグネチャ・挙動に変更はありません。v1.3.0 からの移行に伴うユーザコードの修正は不要です。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "toorpia"
-version = "1.3.0"
+version = "1.4.0"
 description = "Python client for the toorPIA API — mapping and anomaly detection for CSV, waveform, and embedding data"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## 概要

v1.4.0 リリースのための準備PRです（releasing.md の手順1-3）。

- `pyproject.toml`: version 1.3.0 → 1.4.0
- `docs/release-notes/v1.4.0_jp.md`: 新規作成

## リリース内容（v1.3.0 以降）

- **feat**: 保存済みベースマップのXY座標を取得する `get_map_xy()`（#41）
- **docs**: `get_map_xy()` のAPIリファレンス、PEP 668 対処方法（#40）
- **その他（PyPIパッケージ対象外）**: MCP `describe_map` ツール（#42、npm別途配布）

バグ修正なしの後方互換な機能追加のため、パッチではなくマイナーバージョン（1.4.0）としています。

## 確認済み

- ローカルビルド確認（releasing.md の手順）: `python -m build` で sdist + wheel 生成、`twine check` PASSED、同梱物に `toorpia/` パッケージのみ（samples・mcp・秘密情報なし）を確認

マージ後、タグ付け（v1.4.0）と GitHub Release 公開 → publish.yml による PyPI 自動公開に進みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)